### PR TITLE
Changed array_equal to isclose in regression tests

### DIFF
--- a/test/regression/C5G7-TDX/test.py
+++ b/test/regression/C5G7-TDX/test.py
@@ -248,12 +248,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/azurv1_pl_super/test.py
+++ b/test/regression/azurv1_pl_super/test.py
@@ -37,12 +37,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/inf_casmo70/test.py
+++ b/test/regression/inf_casmo70/test.py
@@ -48,12 +48,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/inf_casmo70_td/test.py
+++ b/test/regression/inf_casmo70_td/test.py
@@ -48,12 +48,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/kobayashi3TD/test.py
+++ b/test/regression/kobayashi3TD/test.py
@@ -64,12 +64,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/reed/test.py
+++ b/test/regression/reed/test.py
@@ -46,12 +46,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/slab_absorbium/test.py
+++ b/test/regression/slab_absorbium/test.py
@@ -42,12 +42,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/slab_isobeam_td/test.py
+++ b/test/regression/slab_isobeam_td/test.py
@@ -36,12 +36,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()

--- a/test/regression/slab_moving/test.py
+++ b/test/regression/slab_moving/test.py
@@ -39,12 +39,12 @@ def test():
         name = 'tally/'+score+'/mean'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
         
         name = 'tally/'+score+'/sdev'
         a = output[name][:]
         b = answer[name][:]
-        assert np.array_equal(a,b)
+        assert np.isclose(a,b).all()
 
     output.close()
     answer.close()


### PR DESCRIPTION
Seems different machines were generating slightly different results in the regression testing causing them to fail. Regression tests pass after changing np.array_equal to np.isclose.