### PR TITLE
Automated iQMC Material Index

### DIFF
--- a/examples/eigenvalue/slab_2gu_iqmc/input.py
+++ b/examples/eigenvalue/slab_2gu_iqmc/input.py
@@ -46,7 +46,6 @@ tol = 1e-3
 x = np.linspace(0.0, 6.01275, num=Nx + 1)
 generator = "halton"
 fixed_source = np.zeros(Nx)
-material_idx = np.zeros(Nx, dtype=int)
 phi0 = np.ones((Nx))
 
 # =============================================================================
@@ -57,7 +56,6 @@ mcdc.iQMC(
     x=x,
     phi0=phi0,
     fixed_source=fixed_source,
-    material_idx=material_idx,
     maxitt=maxit,
     tol=tol,
     generator=generator,

--- a/examples/eigenvalue/slab_kornreich_iqmc/input.py
+++ b/examples/eigenvalue/slab_kornreich_iqmc/input.py
@@ -42,8 +42,6 @@ x = np.arange(0.0, 2.6, 0.1)
 Nx = len(x) - 1
 generator = "halton"
 fixed_source = np.zeros(Nx)
-material_idx = np.zeros(Nx, dtype=int)
-material_idx[15:] = 1
 phi0 = np.ones((Nx))
 
 # =============================================================================
@@ -54,7 +52,6 @@ mcdc.iQMC(
     x=x,
     fixed_source=fixed_source,
     phi0=phi0,
-    material_idx=material_idx,
     maxitt=maxit,
     tol=tol,
     generator=generator,

--- a/examples/fixed_source/cooper2_iqmc/input.py
+++ b/examples/fixed_source/cooper2_iqmc/input.py
@@ -44,10 +44,6 @@ generator = "halton"
 # fixed source in lower left corner
 fixed_source = np.zeros((Nx, Ny))
 fixed_source[0 : int(0.25 * Nx), 0 : int(0.25 * Nx)] = 1
-# m_room
-material_idx = np.ones((Nx, Ny), dtype=int)
-# m_barrier
-material_idx[int(0.5 * Nx) : int(0.6 * Nx), 0 : int(0.5 * Nx)] = 0
 
 phi0 = np.ones((Nx, Ny))
 
@@ -56,7 +52,6 @@ mcdc.iQMC(
     y=y,
     fixed_source=fixed_source,
     phi0=phi0,
-    material_idx=material_idx,
     maxitt=maxit,
     tol=tol,
     generator=generator,

--- a/examples/fixed_source/inf_hdpe_iqmc/input.py
+++ b/examples/fixed_source/inf_hdpe_iqmc/input.py
@@ -41,7 +41,7 @@ mcdc.cell([+s1, -s2], m1)
 
 Nx = 5
 fixed_source = np.ones((G, Nx))
-material_idx = np.zeros(Nx, dtype=int)
+# material_idx = np.zeros(Nx, dtype=int)
 phi0 = np.ones((G, Nx))
 
 mcdc.iQMC(
@@ -49,7 +49,6 @@ mcdc.iQMC(
     x=np.linspace(LB, RB, num=Nx + 1),
     fixed_source=fixed_source,
     phi0=phi0,
-    material_idx=material_idx,
     maxitt=25,
     tol=1e-3,
     generator="halton",

--- a/examples/fixed_source/slab_reed_iqmc/input.py
+++ b/examples/fixed_source/slab_reed_iqmc/input.py
@@ -37,8 +37,8 @@ mcdc.cell([+s7, -s8], m4)
 # =============================================================================
 # iQMC Parameters
 # =============================================================================
-N = 1e3
-Nx = 32
+N = 1e2
+Nx = 16
 maxit = 10
 tol = 1e-3
 x = np.linspace(-8, 8, num=Nx + 1)
@@ -49,21 +49,12 @@ fixed_source[int(0.375 * Nx) : int(0.625 * Nx)] = 50.0
 fixed_source[int(0.125 * Nx) : int(0.1875 * Nx)] = 1.0
 fixed_source[int(0.8125 * Nx) : int(0.875 * Nx)] = 1.0
 
-material_idx = np.zeros(Nx, dtype=int)
-material_idx[: int(0.1875 * Nx)] = 3
-material_idx[int(0.1875 * Nx) : int(0.3125 * Nx)] = 2
-material_idx[int(0.3125 * Nx) : int(0.375 * Nx)] = 1
-material_idx[int(0.625 * Nx) : int(0.6875 * Nx)] = 1
-material_idx[int(0.6875 * Nx) : int(0.8125 * Nx)] = 2
-material_idx[int(0.8125 * Nx) :] = 3
-
 phi0 = np.ones((Nx))
 
 mcdc.iQMC(
     x=x,
     fixed_source=fixed_source,
     phi0=phi0,
-    material_idx=material_idx,
     maxitt=maxit,
     tol=tol,
     generator=generator,

--- a/mcdc/input_.py
+++ b/mcdc/input_.py
@@ -1166,7 +1166,6 @@ def iQMC(
     z=None,
     phi0=None,
     fixed_source=None,
-    material_idx=None,
     scramble=False,
     maxitt=25,
     tol=1e-6,
@@ -1212,21 +1211,8 @@ def iQMC(
         fixed_source = np.expand_dims(fixed_source, axis=ax)
         phi0 = np.expand_dims(phi0, axis=ax)
 
-    ax_expand = []
-    if t is None:
-        ax_expand.append(0)
-    if x is None:
-        ax_expand.append(1)
-    if y is None:
-        ax_expand.append(2)
-    if z is None:
-        ax_expand.append(3)
-    for ax in ax_expand:
-        material_idx = np.expand_dims(material_idx, axis=ax)
-
     card["iqmc_flux"] = phi0
     card["iqmc_fixed_source"] = fixed_source
-    card["iqmc_material_idx"] = material_idx
     card["fixed_source_solver"] = fixed_source_solver
     card["eigenmode_solver"] = eigenmode_solver
 

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2860,6 +2860,58 @@ def sample_qmc_group(sample, G):
     return int(np.floor(sample * G))
 
 
+@njit
+def generate_iqmc_material_idx(mcdc):
+    """
+    This algorithm is meant to loop through every spatial cell of the
+    iQMC mesh and assign a material index according to the material_ID at
+    the center of the cell.
+
+    Therefore, the whole cell is treated as the material located at the
+    center of the cell, regardless of whethere there are more materials
+    present.
+
+    A somewhat crude but effient approximation.
+    """
+    iqmc_mesh = mcdc["technique"]["iqmc_mesh"]
+    Nx = len(iqmc_mesh["x"]) - 1
+    Ny = len(iqmc_mesh["y"]) - 1
+    Nz = len(iqmc_mesh["z"]) - 1
+    dx = dy = dz = 1
+    t = 0
+    # variables for cell finding functions
+    trans = np.zeros((3,))
+    universe_ID = 0
+    # create particle to utilize cell finding functions
+    P_new = np.zeros(1, dtype=type_.particle_record)[0]
+
+    # loop through every cell
+    for i in range(Nx):
+        dx = iqmc_mesh["x"][i + 1] - iqmc_mesh["x"][i]
+        x = iqmc_mesh["x"][i] + dx * 0.5
+        for j in range(Ny):
+            dy = iqmc_mesh["y"][j + 1] - iqmc_mesh["y"][j]
+            y = iqmc_mesh["y"][j] + dy * 0.5
+            for k in range(Nz):
+                dx = iqmc_mesh["z"][k + 1] - iqmc_mesh["z"][k]
+                z = iqmc_mesh["z"][k] + dz * 0.5
+
+                # assign cell center position
+                P_new["x"] = x
+                P_new["y"] = y
+                P_new["z"] = z
+
+                # set cell_ID
+                cell_ID = get_particle_cell(P_new, universe_ID, trans, mcdc)
+                cell = mcdc["cells"][cell_ID]
+
+                # set material_ID
+                material_ID = cell["material_ID"]
+
+                # assign material index
+                mcdc["technique"]["iqmc_material_idx"][t, i, j, k] = material_ID
+
+
 # =============================================================================
 # Weight Roulette
 # =============================================================================

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -277,6 +277,8 @@ def loop_particle(P, mcdc):
 
 @njit
 def loop_iqmc(mcdc):
+    # generate material index
+    kernel.generate_iqmc_material_idx(mcdc)
     # function calls from specified solvers
     if mcdc["setting"]["mode_eigenvalue"]:
         power_iteration(mcdc)

--- a/test/regression/eigenvalue/slab_2gu_iqmc/test.py
+++ b/test/regression/eigenvalue/slab_2gu_iqmc/test.py
@@ -48,7 +48,6 @@ def test():
     x = np.linspace(0.0, 6.01275, num=Nx + 1)
     generator = "halton"
     fixed_source = np.zeros(Nx)
-    material_idx = np.zeros(Nx, dtype=int)
     phi0 = np.ones((Nx))
 
     # =========================================================================
@@ -59,7 +58,6 @@ def test():
         x=x,
         phi0=phi0,
         fixed_source=fixed_source,
-        material_idx=material_idx,
         maxitt=maxit,
         tol=tol,
         generator=generator,

--- a/test/regression/eigenvalue/slab_kornreich_iqmc/test.py
+++ b/test/regression/eigenvalue/slab_kornreich_iqmc/test.py
@@ -43,8 +43,6 @@ def test():
     Nx = len(x) - 1
     generator = "halton"
     fixed_source = np.zeros(Nx)
-    material_idx = np.zeros(Nx, dtype=int)
-    material_idx[15:] = 1
     phi0 = np.ones((Nx))
 
     # =========================================================================
@@ -55,7 +53,6 @@ def test():
         x=x,
         fixed_source=fixed_source,
         phi0=phi0,
-        material_idx=material_idx,
         maxitt=maxit,
         tol=tol,
         generator=generator,

--- a/test/regression/fixed_source/cooper2_iqmc/test.py
+++ b/test/regression/fixed_source/cooper2_iqmc/test.py
@@ -49,10 +49,6 @@ def test():
     # fixed source in lower left corner
     fixed_source = np.zeros((Nx, Ny))
     fixed_source[0 : int(0.25 * Nx), 0 : int(0.25 * Nx)] = 1
-    # m_room
-    material_idx = np.ones((Nx, Ny), dtype=int)
-    # m_barrier
-    material_idx[int(0.5 * Nx) : int(0.6 * Nx), 0 : int(0.5 * Nx)] = 0
 
     phi0 = np.ones((Nx, Ny))
 
@@ -61,7 +57,6 @@ def test():
         y=y,
         fixed_source=fixed_source,
         phi0=phi0,
-        material_idx=material_idx,
         maxitt=maxit,
         tol=tol,
         generator=generator,

--- a/test/regression/fixed_source/reed_iqmc/test.py
+++ b/test/regression/fixed_source/reed_iqmc/test.py
@@ -52,21 +52,12 @@ def test():
     fixed_source[int(0.125 * Nx) : int(0.1875 * Nx)] = 1.0
     fixed_source[int(0.8125 * Nx) : int(0.875 * Nx)] = 1.0
 
-    material_idx = np.zeros(Nx, dtype=int)
-    material_idx[: int(0.1875 * Nx)] = 3
-    material_idx[int(0.1875 * Nx) : int(0.3125 * Nx)] = 2
-    material_idx[int(0.3125 * Nx) : int(0.375 * Nx)] = 1
-    material_idx[int(0.625 * Nx) : int(0.6875 * Nx)] = 1
-    material_idx[int(0.6875 * Nx) : int(0.8125 * Nx)] = 2
-    material_idx[int(0.8125 * Nx) :] = 3
-
     phi0 = np.ones((Nx))
 
     mcdc.iQMC(
         x=x,
         fixed_source=fixed_source,
         phi0=phi0,
-        material_idx=material_idx,
         maxitt=maxit,
         tol=tol,
         generator=generator,


### PR DESCRIPTION
Previously the user needed to specify the material index of the iQMC mesh in the input deck, this process is now automated.

`generate_iqmc_material_idx` is meant to loop through every spatial cell of the  iQMC mesh and assign a material index according to the material_ID at the center of the cell.

Therefore, the whole cell is treated as the material located at the center of the cell, regardless of whether there are more materials present. A somewhat crude but easy to implement approximation. We can reduce the error generated by simply adding more spatial cells. 

I think with this function iQMC should be able to run the C5G7 problem.