### PR TITLE
Numba/MPI regression tests

### DIFF
--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -36,7 +36,6 @@ def run():
         print_header_eigenvalue(mcdc)
 
     # Run simulation
-    # TODO: add if iQMC execute iqmc_loop()
     simulation_start = MPI.Wtime()
 
     # iQMC loop

--- a/test/regression/eigenvalue/2d_c5g7/test_1.py
+++ b/test/regression/eigenvalue/2d_c5g7/test_1.py
@@ -225,3 +225,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/eigenvalue/inf_shem361/test.py
+++ b/test/regression/eigenvalue/inf_shem361/test.py
@@ -87,3 +87,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/eigenvalue/slab_kornreich/test.py
+++ b/test/regression/eigenvalue/slab_kornreich/test.py
@@ -1,7 +1,10 @@
 import numpy as np
 import h5py
-
 import mcdc
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
 
 
 def test():
@@ -83,31 +86,35 @@ def test():
     # =========================================================================
     # Check output
     # =========================================================================
+    if rank == 0:
+        output = h5py.File("output.h5", "r")
+        answer = h5py.File("answer.h5", "r")
+        for score in scores:
+            name = "tally/" + score + "/mean"
+            a = output[name][:]
+            b = answer[name][:]
+            assert np.allclose(a, b)
 
-    output = h5py.File("output.h5", "r")
-    answer = h5py.File("answer.h5", "r")
-    for score in scores:
-        name = "tally/" + score + "/mean"
-        a = output[name][:]
-        b = answer[name][:]
+            name = "tally/" + score + "/sdev"
+            a = output[name][:]
+            b = answer[name][:]
+            assert np.allclose(a, b)
+
+        a = output["k_cycle"][:]
+        b = answer["k_cycle"][:]
         assert np.allclose(a, b)
 
-        name = "tally/" + score + "/sdev"
-        a = output[name][:]
-        b = answer[name][:]
+        a = output["k_mean"][()]
+        b = answer["k_mean"][()]
         assert np.allclose(a, b)
 
-    a = output["k_cycle"][:]
-    b = answer["k_cycle"][:]
-    assert np.allclose(a, b)
+        a = output["gyration_radius"][:]
+        b = answer["gyration_radius"][:]
+        assert np.allclose(a, b)
 
-    a = output["k_mean"][()]
-    b = answer["k_mean"][()]
-    assert np.allclose(a, b)
+        output.close()
+        answer.close()
 
-    a = output["gyration_radius"][:]
-    b = answer["gyration_radius"][:]
-    assert np.allclose(a, b)
 
-    output.close()
-    answer.close()
+if __name__ == "__main__":
+    test()

--- a/test/regression/eigenvalue/slab_kornreich_iqmc/test.py
+++ b/test/regression/eigenvalue/slab_kornreich_iqmc/test.py
@@ -1,6 +1,10 @@
 import numpy as np
 import h5py
 import mcdc
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
 
 
 def test():
@@ -58,7 +62,7 @@ def test():
         generator=generator,
     )
     # Setting
-    mcdc.setting(N_particle=N)
+    mcdc.setting(N_particle=N, progress_bar=False)
     mcdc.eigenmode()
 
     # Run
@@ -67,20 +71,20 @@ def test():
     # =========================================================================
     # Check output
     # =========================================================================
+    if rank == 0:
+        output = h5py.File("output.h5", "r")
+        answer = h5py.File("answer.h5", "r")
 
-    output = h5py.File("output.h5", "r")
-    answer = h5py.File("answer.h5", "r")
+        a = answer["tally/iqmc_flux"][:]
+        b = output["tally/iqmc_flux"][:]
+        assert np.allclose(a, b)
 
-    a = answer["tally/iqmc_flux"][:]
-    b = output["tally/iqmc_flux"][:]
-    assert np.allclose(a, b)
+        a = output["k_eff"][()]
+        b = answer["k_eff"][()]
+        assert np.allclose(a, b)
 
-    a = output["k_eff"][()]
-    b = answer["k_eff"][()]
-    assert np.allclose(a, b)
-
-    output.close()
-    answer.close()
+        output.close()
+        answer.close()
 
 
 if __name__ == "__main__":

--- a/test/regression/fixed_source/C5G7-TDX/test.py
+++ b/test/regression/fixed_source/C5G7-TDX/test.py
@@ -295,3 +295,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/C5G7-TDX/test_2.py
+++ b/test/regression/fixed_source/C5G7-TDX/test_2.py
@@ -295,3 +295,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/azurv1_pl_super/test.py
+++ b/test/regression/fixed_source/azurv1_pl_super/test.py
@@ -51,3 +51,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/cooper2/test.py
+++ b/test/regression/fixed_source/cooper2/test.py
@@ -61,3 +61,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/cooper2_iqmc/test.py
+++ b/test/regression/fixed_source/cooper2_iqmc/test.py
@@ -81,3 +81,7 @@ def test():
     answer.close()
 
     assert np.allclose(a, b)
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/dsm_azurv1/test.py
+++ b/test/regression/fixed_source/dsm_azurv1/test.py
@@ -56,3 +56,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/dsm_lattice/test.py
+++ b/test/regression/fixed_source/dsm_lattice/test.py
@@ -66,3 +66,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/inf_casmo70/test.py
+++ b/test/regression/fixed_source/inf_casmo70/test.py
@@ -66,3 +66,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/inf_casmo70_td/test.py
+++ b/test/regression/fixed_source/inf_casmo70_td/test.py
@@ -68,3 +68,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/kobayashi3TD/test.py
+++ b/test/regression/fixed_source/kobayashi3TD/test.py
@@ -79,3 +79,7 @@ def test():
     output.close()
     answer.close()
     assert True
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/reed/test.py
+++ b/test/regression/fixed_source/reed/test.py
@@ -2,6 +2,10 @@ import numpy as np
 import h5py
 
 import mcdc
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
 
 
 def test():
@@ -39,19 +43,23 @@ def test():
     # =========================================================================
     # Check output
     # =========================================================================
+    if rank == 0:
+        output = h5py.File("output.h5", "r")
+        answer = h5py.File("answer.h5", "r")
+        for score in scores:
+            name = "tally/" + score + "/mean"
+            a = output[name][:]
+            b = answer[name][:]
+            assert np.isclose(a, b).all()
 
-    output = h5py.File("output.h5", "r")
-    answer = h5py.File("answer.h5", "r")
-    for score in scores:
-        name = "tally/" + score + "/mean"
-        a = output[name][:]
-        b = answer[name][:]
-        assert np.isclose(a, b).all()
+            name = "tally/" + score + "/sdev"
+            a = output[name][:]
+            b = answer[name][:]
+            assert np.isclose(a, b).all()
 
-        name = "tally/" + score + "/sdev"
-        a = output[name][:]
-        b = answer[name][:]
-        assert np.isclose(a, b).all()
+        output.close()
+        answer.close()
 
-    output.close()
-    answer.close()
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/reed_iqmc/test.py
+++ b/test/regression/fixed_source/reed_iqmc/test.py
@@ -80,3 +80,7 @@ def test():
     answer.close()
 
     assert np.allclose(a, b)
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/slab_absorbium/test.py
+++ b/test/regression/fixed_source/slab_absorbium/test.py
@@ -52,3 +52,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/slab_isobeam_td/test.py
+++ b/test/regression/fixed_source/slab_isobeam_td/test.py
@@ -46,3 +46,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/fixed_source/slab_moving/test.py
+++ b/test/regression/fixed_source/slab_moving/test.py
@@ -51,3 +51,7 @@ def test():
 
     output.close()
     answer.close()
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/test_mpi.py
+++ b/test/regression/test_mpi.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import subprocess
+
+
+def test():
+    """
+    This test runs the specified regression tests with a specified number
+    of MPI processes. This way, we can compare the numba results directly
+    to the python mode results.
+
+    This test will not work on Windows machines
+
+    """
+
+    tests = [
+        "eigenvalue/slab_kornreich_iqmc/",
+        "fixed_source/reed/",
+    ]
+
+    for i in range(len(tests)):
+        cwd = tests[i]
+        result = subprocess.run(["mpiexec", "-np", "2", "python", "test.py"], cwd=cwd)
+        assert result.returncode == 0
+
+
+if __name__ == "__main__":
+    test()

--- a/test/regression/test_numba.py
+++ b/test/regression/test_numba.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import subprocess
+
+
+def test():
+    """
+    This test runs the specified regression tests in numba mode. This way,
+    we can compare the numba results directly to the python mode results.
+
+    This test will not work on Windows machines
+
+    """
+
+    tests = [
+        "eigenvalue/slab_kornreich/",
+        "eigenvalue/slab_kornreich_iqmc/",
+        "fixed_source/reed/",
+    ]
+
+    for i in range(len(tests)):
+        cwd = tests[i]
+        result = subprocess.run(["python", "test.py", "--mode=numba"], cwd=cwd)
+        assert result.returncode == 0
+
+
+if __name__ == "__main__":
+    test()

--- a/test/unit/test_mpi.py
+++ b/test/unit/test_mpi.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import subprocess
+
+
+def test():
+    """
+    This test runs the specified regression tests with a specified number
+    of MPI processes. This way, we can compare the numba results directly
+    to the python mode results.
+
+    This test will not work on Windows machines
+
+    """
+
+    tests = [
+        "../regression/eigenvalue/slab_kornreich_iqmc/",
+        "../regression/fixed_source/reed/",
+    ]
+
+    for i in range(len(tests)):
+        cwd = tests[i]
+        result = subprocess.run(["mpiexec", "-np", "2", "python", "test.py"], cwd=cwd)
+        assert result.returncode == 0
+
+
+if __name__ == "__main__":
+    test()

--- a/test/unit/test_numba.py
+++ b/test/unit/test_numba.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import subprocess
+
+
+def test():
+    """
+    This test runs the specified regression tests in numba mode. This way,
+    we can compare the numba results directly to the python mode results.
+
+    This test will not work on Windows machines
+
+    """
+
+    tests = [
+        "../regression/eigenvalue/slab_kornreich/",
+        "../regression/eigenvalue/slab_kornreich_iqmc/",
+        "../regression/fixed_source/reed/",
+    ]
+
+    for i in range(len(tests)):
+        cwd = tests[i]
+        result = subprocess.run(["python", "test.py", "--mode=numba"], cwd=cwd)
+        assert result.returncode == 0
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
There are two additional files in `test/regression/`, `test_numba.py` and '`test_mpi.py`.

In both tests, we can specify the regression tests (fixed_source or eigenvalue) that we also want to run in Numba mode or with multiple MPI processes. I use python sub-processes to launch the specified regression test files. The advantage here is I did not have rewrite the regression tests and we compare to the same solution that's produced in the python/serial test.

We can easily add more tests to the lists in each, but for MPI tests you need to go in and add
```
from mpi4py import MPI
comm = MPI.COMM_WORLD
rank = comm.Get_rank()
```
at the top of the file. Then add 
```
    if rank == 0:
        output = h5py.File("output.h5", "r")
        answer = h5py.File("answer.h5", "r")
    ....
```
This is because only one process can open the H5 file at a time.