### PR TITLE
Improvements to weight windows

### DIFF
--- a/mcdc/card.py
+++ b/mcdc/card.py
@@ -110,8 +110,10 @@ class InputCard:
             "implicit_capture": False,
             "population_control": False,
             "pct": PCT_NONE,
+            "pc_factor": 1.0,
             "weight_window": False,
             "ww": np.ones([1, 1, 1, 1]),
+            "weight_window_width": 2.5,
             "ww_mesh": {
                 "x": np.array([-INF, INF]),
                 "y": np.array([-INF, INF]),

--- a/mcdc/card.py
+++ b/mcdc/card.py
@@ -113,7 +113,7 @@ class InputCard:
             "pc_factor": 1.0,
             "weight_window": False,
             "ww": np.ones([1, 1, 1, 1]),
-            "weight_window_width": 2.5,
+            "ww_width": 2.5,
             "ww_mesh": {
                 "x": np.array([-INF, INF]),
                 "y": np.array([-INF, INF]),

--- a/mcdc/input_.py
+++ b/mcdc/input_.py
@@ -1148,7 +1148,7 @@ def weight_window(x=None, y=None, z=None, t=None, window=None, width=None):
 
     # Set width
     if width is not None:
-        card["weight_window_width"] = width
+        card["ww_width"] = width
 
     # Set mesh
     if x is not None:

--- a/mcdc/input_.py
+++ b/mcdc/input_.py
@@ -1142,9 +1142,13 @@ def census(t, pct="none"):
         population_control(pct)
 
 
-def weight_window(x=None, y=None, z=None, t=None, window=None):
+def weight_window(x=None, y=None, z=None, t=None, window=None, width=None):
     card = mcdc.input_card.technique
     card["weight_window"] = True
+
+    # Set width
+    if width is not None:
+        card["weight_window_width"] = width
 
     # Set mesh
     if x is not None:

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2364,7 +2364,7 @@ def weight_window(P, mcdc):
     p = P["w"] / w_target
 
     # Window width
-    width = mcdc["technique"]["weight_window_width"]
+    width = mcdc["technique"]["ww_width"]
 
     # If above target
     if p > width:

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2353,43 +2353,43 @@ def time_boundary(P, mcdc):
 def weight_window(P, mcdc):
     # Get indices
     t, x, y, z, outside = mesh_get_index(P, mcdc["technique"]["ww_mesh"])
-    if not outside:
-        # Target weight
-        w_target = mcdc["technique"]["ww"][t, x, y, z]
+        
+    # Target weight
+    w_target = mcdc["technique"]["ww"][t, x, y, z]
 
-        # Population control factor
-        w_target *= mcdc["technique"]["pc_factor"]
+    # Population control factor
+    w_target *= mcdc["technique"]["pc_factor"]
 
-        # Surviving probability
-        p = P["w"] / w_target
+    # Surviving probability
+    p = P["w"] / w_target
 
-        # Window Width
-        width = mcdc["technique"]["weight_window_width"]
+    # Window Width
+    width = mcdc["technique"]["weight_window_width"]
 
-        # If above target
-        if p > width:
-            # Set target weight
+    # If above target
+    if p > width:
+        # Set target weight
+        P["w"] = w_target
+
+        # Splitting (keep the original particle)
+        n_split = math.floor(p)
+        for i in range(n_split - 1):
+            add_particle(copy_particle(P), mcdc["bank_active"])
+
+        # Russian roulette
+        p -= n_split
+        xi = rng(mcdc)
+        if xi <= p:
+            add_particle(copy_particle(P), mcdc["bank_active"])
+
+    # Below target
+    elif p < 1.0 / width:
+        # Russian roulette
+        xi = rng(mcdc)
+        if xi > p:
+            P["alive"] = False
+        else:
             P["w"] = w_target
-
-            # Splitting (keep the original particle)
-            n_split = math.floor(p)
-            for i in range(n_split - 1):
-                add_particle(copy_particle(P), mcdc["bank_active"])
-
-            # Russian roulette
-            p -= n_split
-            xi = rng(mcdc)
-            if xi <= p:
-                add_particle(copy_particle(P), mcdc["bank_active"])
-
-        # Below target
-        elif p < 1.0 / width:
-            # Russian roulette
-            xi = rng(mcdc)
-            if xi > p:
-                P["alive"] = False
-            else:
-                P["w"] = w_target
 
 
 # ==============================================================================

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2353,7 +2353,7 @@ def time_boundary(P, mcdc):
 def weight_window(P, mcdc):
     # Get indices
     t, x, y, z, outside = mesh_get_index(P, mcdc["technique"]["ww_mesh"])
-        
+
     # Target weight
     w_target = mcdc["technique"]["ww"][t, x, y, z]
 
@@ -2363,7 +2363,7 @@ def weight_window(P, mcdc):
     # Surviving probability
     p = P["w"] / w_target
 
-    # Window Width
+    # Window width
     width = mcdc["technique"]["weight_window_width"]
 
     # If above target

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -672,6 +672,9 @@ def pct_combing(mcdc):
     # Teeth distance
     td = N / M
 
+    # Update population control factor
+    mcdc["technique"]["pc_factor"] *= td
+
     # Tooth offset
     xi = rng(mcdc)
     offset = xi * td
@@ -705,6 +708,9 @@ def pct_combing_weight(mcdc):
 
     # Teeth distance
     td = W / M
+
+    # Update population control factor
+    mcdc["technique"]["pc_factor"] *= td
 
     # Tooth offset
     xi = rng(mcdc)
@@ -2347,35 +2353,43 @@ def time_boundary(P, mcdc):
 def weight_window(P, mcdc):
     # Get indices
     t, x, y, z, outside = mesh_get_index(P, mcdc["technique"]["ww_mesh"])
+    if not outside:
+        # Target weight
+        w_target = mcdc["technique"]["ww"][t, x, y, z]
 
-    # Target weight
-    w_target = mcdc["technique"]["ww"][t, x, y, z]
+        # Population control factor
+        w_target *= mcdc["technique"]["pc_factor"]
 
-    # Surviving probability
-    p = P["w"] / w_target
+        # Surviving probability
+        p = P["w"] / w_target
 
-    # Set target weight
-    P["w"] = w_target
+        # Window Width
+        width = mcdc["technique"]["weight_window_width"]
 
-    # If above target
-    if p > 1.0:
-        # Splitting (keep the original particle)
-        n_split = math.floor(p)
-        for i in range(n_split - 1):
-            add_particle(copy_particle(P), mcdc["bank_active"])
+        # If above target
+        if p > width:
+            # Set target weight
+            P["w"] = w_target
 
-        # Russian roulette
-        p -= n_split
-        xi = rng(mcdc)
-        if xi <= p:
-            add_particle(copy_particle(P), mcdc["bank_active"])
+            # Splitting (keep the original particle)
+            n_split = math.floor(p)
+            for i in range(n_split - 1):
+                add_particle(copy_particle(P), mcdc["bank_active"])
 
-    # Below target
-    else:
-        # Russian roulette
-        xi = rng(mcdc)
-        if xi > p:
-            P["alive"] = False
+            # Russian roulette
+            p -= n_split
+            xi = rng(mcdc)
+            if xi <= p:
+                add_particle(copy_particle(P), mcdc["bank_active"])
+
+        # Below target
+        elif p < 1.0/width:
+            # Russian roulette
+            xi = rng(mcdc)
+            if xi > p:
+                P["alive"] = False
+            else:
+                P["w"] = w_target
 
 
 # ==============================================================================

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2383,7 +2383,7 @@ def weight_window(P, mcdc):
                 add_particle(copy_particle(P), mcdc["bank_active"])
 
         # Below target
-        elif p < 1.0/width:
+        elif p < 1.0 / width:
             # Russian roulette
             xi = rng(mcdc)
             if xi > p:

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -247,7 +247,7 @@ def loop_particle(P, mcdc):
             kernel.time_boundary(P, mcdc)
 
         # Apply weight window
-        if mcdc["technique"]["weight_window"]:
+        elif mcdc["technique"]["weight_window"]:
             kernel.weight_window(P, mcdc)
 
         # Apply weight roulette

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -287,7 +287,9 @@ def prepare():
 
     # WW windows
     mcdc["technique"]["ww"] = input_card.technique["ww"]
-    mcdc["technique"]["weight_window_width"] = input_card.technique["weight_window_width"]
+    mcdc["technique"]["weight_window_width"] = input_card.technique[
+        "weight_window_width"
+    ]
 
     # =========================================================================
     # Weight roulette

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -287,9 +287,7 @@ def prepare():
 
     # WW windows
     mcdc["technique"]["ww"] = input_card.technique["ww"]
-    mcdc["technique"]["weight_window_width"] = input_card.technique[
-        "weight_window_width"
-    ]
+    mcdc["technique"]["ww_width"] = input_card.technique["ww_width"]
 
     # =========================================================================
     # Weight roulette

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -275,6 +275,7 @@ def prepare():
 
     # Population control technique (PCT)
     mcdc["technique"]["pct"] = input_card.technique["pct"]
+    mcdc["technique"]["pc_factor"] = input_card.technique["pc_factor"]
 
     # =========================================================================
     # Weight window (WW)
@@ -286,6 +287,7 @@ def prepare():
 
     # WW windows
     mcdc["technique"]["ww"] = input_card.technique["ww"]
+    mcdc["technique"]["weight_window_width"] = input_card.technique["weight_window_width"]
 
     # =========================================================================
     # Weight roulette

--- a/mcdc/type_.py
+++ b/mcdc/type_.py
@@ -314,7 +314,14 @@ def make_type_source(G):
 
 
 # Score lists
-score_tl_list = ("flux", "current", "eddington", "density", "fission", "total")
+score_tl_list = (
+    "flux",
+    "current",
+    "eddington",
+    "density",
+    "fission",
+    "total",
+)
 score_x_list = (
     "flux_x",
     "current_x",
@@ -492,7 +499,7 @@ def make_type_technique(N_particle, G, card):
     # Population control
     # =========================================================================
 
-    struct += [("pct", int64)]
+    struct += [("pct", int64), ("pc_factor", float64)]
 
     # =========================================================================
     # Weight window
@@ -501,6 +508,7 @@ def make_type_technique(N_particle, G, card):
     # Mesh
     mesh, Nx, Ny, Nz, Nt, Nmu, N_azi, Ng = make_type_mesh(card["ww_mesh"])
     struct += [("ww_mesh", mesh)]
+    struct += [("weight_window_width", float64)]
 
     # Window
     struct += [("ww", float64, (Nt, Nx, Ny, Nz))]

--- a/mcdc/type_.py
+++ b/mcdc/type_.py
@@ -508,7 +508,7 @@ def make_type_technique(N_particle, G, card):
     # Mesh
     mesh, Nx, Ny, Nz, Nt, Nmu, N_azi, Ng = make_type_mesh(card["ww_mesh"])
     struct += [("ww_mesh", mesh)]
-    struct += [("weight_window_width", float64)]
+    struct += [("ww_width", float64)]
 
     # Window
     struct += [("ww", float64, (Nt, Nx, Ny, Nz))]


### PR DESCRIPTION
Added a weight window width parameter. This parameter controls how far away from the target weight splitting or roulette occurs. The default value is set to a factor of 2.5.
Added a factor to track to the amount of population control. This is used so that weight windows do not re-split particles after combing.