### PR TITLE
debug parallel issue on source bank access

### DIFF
--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -121,9 +121,10 @@ def loop_source(seed, mcdc):
 
     # Loop over particle sources
     work_start = mcdc["mpi_work_start"]
-    work_end = work_start + mcdc["mpi_work_size"]
-    for idx_work in range(work_start, work_end):
-        seed_work = kernel.split_seed(idx_work, seed)
+    work_size = mcdc['mpi_work_size']
+    work_end = work_start + work_size
+    for idx_work in range(work_size):
+        seed_work = kernel.split_seed(work_start + idx_work, seed)
 
         # Particle tracker
         if mcdc["setting"]["track_particle"]:

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -121,7 +121,7 @@ def loop_source(seed, mcdc):
 
     # Loop over particle sources
     work_start = mcdc["mpi_work_start"]
-    work_size = mcdc['mpi_work_size']
+    work_size = mcdc["mpi_work_size"]
     work_end = work_start + work_size
     for idx_work in range(work_size):
         seed_work = kernel.split_seed(work_start + idx_work, seed)


### PR DESCRIPTION
The issue was due to an inconsistency in accessing the local source bank index. The bug was created when we added the new rng, accidentally changing the work indexing due to working on reproducible seed splitting.