### PR TITLE
Testing Refactor, New Documentaiton, & Cont Energy Xsec Config script

### DIFF
--- a/.github/workflows/mpi_numba_reg.yml
+++ b/.github/workflows/mpi_numba_reg.yml
@@ -1,10 +1,14 @@
-name: test
+name: Regression Test - Numba and MPI
 
 on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11
@@ -25,26 +29,8 @@ jobs:
     - name: Patch Numba
       run : |
         bash .github/workflows/patch.sh
-    - name: Unit Test
-      run: |
-        pytest
-    - name: Regression Test - Python
-      run: |
-        cd test/regression
-        python run.py
-    - name: Regression Test - MPI
-      run: |
-        cd test/regression
-        python run.py --mpiexec=4
-        python run.py --mpiexec=2
-    - name: Regression Test - Numba
-      run: |
-        cd test/regression
-        python run.py --mode=numba
     - name: Regression Test - Numba and MPI
       run: |
-        cd test/regression
-        python run.py --mode=numba --mpiexec=4
-        python run.py --mode=numba --mpiexec=2
-    # TODO: Performance test
-    # TODO: GPU test
+          cd test/regression
+          python run.py --mode=numba --mpiexec=4
+          python run.py --mode=numba --mpiexec=2

--- a/.github/workflows/mpi_numba_reg.yml
+++ b/.github/workflows/mpi_numba_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/mpi_numba_reg.yml
+++ b/.github/workflows/mpi_numba_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/mpi_reg.yml
+++ b/.github/workflows/mpi_reg.yml
@@ -1,0 +1,36 @@
+name: Regression Test - MPI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest", "macos-latest"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
+    - name: debug
+      run: |
+        pwd
+        ls
+    - uses: mpi4py/setup-mpi@v1
+    - name: Install dependencies
+      run: |
+        #sudo apt-get install libopenmpi-dev
+        pip install numpy numba h5py matplotlib scipy pytest colorama mpi4py ngsolve distinctipy
+        pip list 
+        pip install -e .
+    - name: Patch Numba
+      run : |
+        bash .github/workflows/patch.sh
+    - name: Regression Test - MPI
+      run: |
+        cd test/regression
+        python run.py --mpiexec=4
+        python run.py --mpiexec=2

--- a/.github/workflows/mpi_reg.yml
+++ b/.github/workflows/mpi_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/mpi_reg.yml
+++ b/.github/workflows/mpi_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/numba_reg.yml
+++ b/.github/workflows/numba_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/numba_reg.yml
+++ b/.github/workflows/numba_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/numba_reg.yml
+++ b/.github/workflows/numba_reg.yml
@@ -1,0 +1,35 @@
+name: Regression Test - Numba
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest", "macos-latest"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
+    - name: debug
+      run: |
+        pwd
+        ls
+    - uses: mpi4py/setup-mpi@v1
+    - name: Install dependencies
+      run: |
+        #sudo apt-get install libopenmpi-dev
+        pip install numpy numba h5py matplotlib scipy pytest colorama mpi4py ngsolve distinctipy
+        pip list 
+        pip install -e .
+    - name: Patch Numba
+      run : |
+        bash .github/workflows/patch.sh
+    - name: Regression Test - Numba
+      run: |
+          cd test/regression
+          python run.py --mode=numba

--- a/.github/workflows/numba_reg.yml
+++ b/.github/workflows/numba_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/python_reg.yml
+++ b/.github/workflows/python_reg.yml
@@ -1,0 +1,35 @@
+name: Regression Test - Python
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest", "macos-latest"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
+    - name: debug
+      run: |
+        pwd
+        ls
+    - uses: mpi4py/setup-mpi@v1
+    - name: Install dependencies
+      run: |
+        #sudo apt-get install libopenmpi-dev
+        pip install numpy numba h5py matplotlib scipy pytest colorama mpi4py ngsolve distinctipy
+        pip list 
+        pip install -e .
+    - name: Patch Numba
+      run : |
+        bash .github/workflows/patch.sh
+    - name: Regression Test - Python
+      run: |
+          cd test/regression
+          python run.py

--- a/.github/workflows/python_reg.yml
+++ b/.github/workflows/python_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/python_reg.yml
+++ b/.github/workflows/python_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/python_reg.yml
+++ b/.github/workflows/python_reg.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,34 @@
+name: Unit Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+            os: ["ubuntu-latest", "macos-latest"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
+    - name: debug
+      run: |
+        pwd
+        ls
+    - uses: mpi4py/setup-mpi@v1
+    - name: Install dependencies
+      run: |
+        #sudo apt-get install libopenmpi-dev
+        pip install numpy numba h5py matplotlib scipy pytest colorama mpi4py ngsolve distinctipy
+        pip list 
+        pip install -e .
+    - name: Patch Numba
+      run : |
+        bash .github/workflows/patch.sh
+    - name: Unit Test
+      run : |
+          pytest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest", "macos-latest", "macos-latest-large", "windows-latest"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ build
 .eggs
 mcdc.egg-info
 
+# Material Data
+mcdc_xs
+MCDC-Xsec
+
 # Python cache
 __pycache__
 *.pyc

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MC/DC is a performant, scalable, and machine-portable Python-based Monte Carlo
 neutron transport software currently developed in the Center for Exascale Monte 
 Carlo Neutron Transport ([CEMeNT](https://cement-psaap.github.io/)).
 
-*Please Note that this project is in the early stages of devlopment (not even an alpha).* That being said enjoy!
+*Please Note that this project is in the early stages of devlopment.* We welcome any and all collaborators, feel free to reach out via comments or submit a PR! Enjoy!
 
 ## Installation
 

--- a/config_cont_energy.sh
+++ b/config_cont_energy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "WARNING: Seemless continous energy functionality"
+echo "is only avlible to CEMeNT members."
+echo " "
+
+# downloading library from zenodo
+git clone git@github.com:CEMeNT-PSAAP/MCDC-Xsec.git
+
+cd MCDC-Xsec
+
+# untaring file
+tar -xvzf mcdc_xs.tar.gz
+
+# going into the cross section library directory
+cd mcdc_xs
+
+# getting the present working direcotry
+xsec_dir=$(pwd)
+
+# exporting the needed enviroment variable for current enviroment
+export MCDC_XSLIB="${xsec_dir}"
+
+# sotring that enviroment variable in bashrc for future runs
+export MCDC_XSLIB="${xsec_dir}">> ~/.bashrc 
+
+# printing a complete message
+echo "MCDC_XSLIB set as $MCDC_XSLIB in ~/.bashrc"

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -31,7 +31,47 @@ in the top level MC/DC direcory and all nessacary changes will be automatically 
 Testing
 -------
 
-MC/DC has a robust testing suite that your changes must be able to adhere to
+MC/DC has a robust testing suite that your changes must be able to pass before a PR is accepted.
+Unit tests for functions that have them are ran in a pure python from.
+Mostly this is for ensuring input operability
+A regression test suite (including models with anylitical and expermental soultions) is provided to ensure accuracy and precision of MC/DC.
+
+Our test suite runs on every PR, and Push.
+Our github based CI runs for, 
+* linux-64 (x86)
+* osx-64 (x86, intel based macs)
+* win-64 (x86)
+* osx-arm64 (apple sillicon)
+while we do not have continous integration we have validated MC/DC on
+* linux-aarch64 (IBM POWER9)
+* linux-nvidia-cuda
+* linux-amd-gcn
+
+To run the regression tests locally, navigate to ``\MCDC\tests\regression`` and run,
+
+.. code-block:: sh
+    python run.py <OPTION_FLAG(s)>
+
+and all the tests will run. Various option ``OPTION_FLAG`` are accepted to control the tests ran,
+
+* Run a specific test (with wildcard `*` support): ``--name=<test_name>`` 
+* Run in Numba mode: ``--mode=numba``
+* Run in multiple MPI ranks (currently support `mpiexec` and `srun`): ``--mpiexec=<number of ranks>``
+
+Note that flags can be combined. To add a new test:
+
+#. Create a folder. The name of the folder will be the test name.
+#. Add the input file. Name it`input.py`.
+#. Add the answer key file. Name it `answer.h5`.
+#. Make sure that the number of particles run is large enough for a good test.
+#. If the test runs longer than 5 seconds, consider decreasing the number of particles.
+
+When adding a new hardware backend a new enstantioation of the test suit should be made.
+This is done with github actions. 
+See the (.github/workflows) for examples.
+
+If a new simulation type is added (e.g. quasi montecarlo w/ davidson's method, residual monte carlo, intrisuve uq) more regression tests shuold be added with your PR.
+If you are wondering accomidations.
 
 
 -------------
@@ -39,6 +79,26 @@ Documentaiton
 -------------
 
 
---------------
-Pull Requiests
---------------
+It's not everything it needs to be but we are trying!
+If your contirbution changes the behavior of the input deck, instilation process, or testing infrastructure your contribution must include alteration to this documentaiton.
+That can be done by editing the RST files in ``/MCDC/docs/source/<FILENAME>.rst``.
+
+
+-------------
+Pull Requstes
+-------------
+
+
+MC/DC works off of a fork workflow in which contributors fork our repo, make allterations, and submit a pull requests.
+You should only submit a pull request once your code passes all tests, is properly linted, you have edited documentaiton (if nessacary), and added any new tests (if needed).
+
+Within your pull request documetnation please list:
+#. Type of PR (e.g. Enhancment, bugfix, etc);
+#. Link to any theroy to understand what you are doing;
+#. Link to any open/closed issues if applicable;
+#. New functionalties implemented
+#. Depreicated functionalities
+#. New dependincies needed (we don't add these lightly)
+#. Anything else we need to give you the thorough code review you deserve!
+
+If these things aren't listed we will ask for clarifying qustions!

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -1,15 +1,15 @@
 .. _contributions:
 
-=================
-Contibution Guide
-=================
+==================
+Contribution Guide
+==================
 
-Thank you for looking to contirbute to MC/DC! 
-We are really exctied to see what you bring to this exciting open source project!
-Wheater you are here to make a single PR and never return, or want to become a maintiner we are pumped to work with you.
-We have regular devlopers meetings for any and all who are interested to discss contributions to this code base.
+Thank you for looking to contribute to MC/DC! 
+We are really excited to see what you bring to this exciting open source project!
+Whether you are here to make a single PR and never return, or want to become a maintainer we are pumped to work with you.
+We have regular developers meetings for any and all who are interested to discuss contributions to this code base.
 
-This describes the processes of contributing to MC/DC for both internal (CEMeNT) and external devlopers.
+This describes the processes of contributing to MC/DC for both internal (CEMeNT) and external developers.
 
 Please note our `code of conduct <>` which we take seriously
 
@@ -18,14 +18,14 @@ Code Styling
 ------------
 
 Our code is autolinted for the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`.
-Your contirbutions will not be merged unless you follow this code style.
+Your contributions will not be merged unless you follow this code style.
 It's pretty easy to do this locally, just run,
 
 .. code-block:: sh
     pip install black
     black .
 
-in the top level MC/DC direcory and all nessacary changes will be automatically made for you.
+in the top level MC/DC directory and all necessary changes will be automatically made for you.
 
 -------
 Testing
@@ -34,18 +34,13 @@ Testing
 MC/DC has a robust testing suite that your changes must be able to pass before a PR is accepted.
 Unit tests for functions that have them are ran in a pure python from.
 Mostly this is for ensuring input operability
-A regression test suite (including models with anylitical and expermental soultions) is provided to ensure accuracy and precision of MC/DC.
+A regression test suite (including models with analytical and experimental solutions) is provided to ensure accuracy and precision of MC/DC.
 
 Our test suite runs on every PR, and Push.
 Our github based CI runs for, 
 * linux-64 (x86)
 * osx-64 (x86, intel based macs)
-* win-64 (x86)
-* osx-arm64 (apple sillicon)
-while we do not have continous integration we have validated MC/DC on
-* linux-aarch64 (IBM POWER9)
-* linux-nvidia-cuda
-* linux-amd-gcn
+while we do not have continuos integration we have validated MC/DC on other systems.
 
 To run the regression tests locally, navigate to ``\MCDC\tests\regression`` and run,
 
@@ -66,39 +61,39 @@ Note that flags can be combined. To add a new test:
 #. Make sure that the number of particles run is large enough for a good test.
 #. If the test runs longer than 5 seconds, consider decreasing the number of particles.
 
-When adding a new hardware backend a new enstantioation of the test suit should be made.
+When adding a new hardware backend a new instantiation of the test suit should be made.
 This is done with github actions. 
 See the (.github/workflows) for examples.
 
-If a new simulation type is added (e.g. quasi montecarlo w/ davidson's method, residual monte carlo, intrisuve uq) more regression tests shuold be added with your PR.
-If you are wondering accomidations.
+If a new simulation type is added (e.g. quasi montecarlo w/ davidson's method, residual monte carlo, intrusive uq) more regression tests should be added with your PR.
+If you are wondering accommodations.
 
 
 -------------
-Documentaiton
+Documentation
 -------------
 
 
 It's not everything it needs to be but we are trying!
-If your contirbution changes the behavior of the input deck, instilation process, or testing infrastructure your contribution must include alteration to this documentaiton.
+If your contribution changes the behavior of the input deck, instillation process, or testing infrastructure your contribution must include alteration to this documentaiton.
 That can be done by editing the RST files in ``/MCDC/docs/source/<FILENAME>.rst``.
 
 
 -------------
-Pull Requstes
+Pull Requests
 -------------
 
 
-MC/DC works off of a fork workflow in which contributors fork our repo, make allterations, and submit a pull requests.
-You should only submit a pull request once your code passes all tests, is properly linted, you have edited documentaiton (if nessacary), and added any new tests (if needed).
+MC/DC works off of a fork workflow in which contributors fork our repo, make alterations, and submit a pull requests.
+You should only submit a pull request once your code passes all tests, is properly linted, you have edited documentation (if necessary), and added any new tests (if needed).
 
-Within your pull request documetnation please list:
-#. Type of PR (e.g. Enhancment, bugfix, etc);
-#. Link to any theroy to understand what you are doing;
+Within your pull request documentation please list:
+#. Type of PR (e.g. enhancement, bugfix, etc);
+#. Link to any theory to understand what you are doing;
 #. Link to any open/closed issues if applicable;
-#. New functionalties implemented
-#. Depreicated functionalities
-#. New dependincies needed (we don't add these lightly)
+#. New functionalities implemented
+#. Depreciated functionalities
+#. New dependencies needed (we don't add these lightly)
 #. Anything else we need to give you the thorough code review you deserve!
 
-If these things aren't listed we will ask for clarifying qustions!
+If these things aren't listed we will ask for clarifying questions!

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -1,0 +1,44 @@
+.. _contributions:
+
+=================
+Contibution Guide
+=================
+
+Thank you for looking to contirbute to MC/DC! 
+We are really exctied to see what you bring to this exciting open source project!
+Wheater you are here to make a single PR and never return, or want to become a maintiner we are pumped to work with you.
+We have regular devlopers meetings for any and all who are interested to discss contributions to this code base.
+
+This describes the processes of contributing to MC/DC for both internal (CEMeNT) and external devlopers.
+
+Please note our `code of conduct <>` which we take seriously
+
+------------
+Code Styling
+------------
+
+Our code is autolinted for the `Black code style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`.
+Your contirbutions will not be merged unless you follow this code style.
+It's pretty easy to do this locally, just run,
+
+.. code-block:: sh
+    pip install black
+    black .
+
+in the top level MC/DC direcory and all nessacary changes will be automatically made for you.
+
+-------
+Testing
+-------
+
+MC/DC has a robust testing suite that your changes must be able to adhere to
+
+
+-------------
+Documentaiton
+-------------
+
+
+--------------
+Pull Requiests
+--------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ by the `Center for Exascale Monte Carlo Neutron Transport <https://cement-psaap.
    :maxdepth: 1
 
    install
+   contributions
    pythonapi/index
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,15 @@ by the `Center for Exascale Monte Carlo Neutron Transport <https://cement-psaap.
    The project is in the early stages of *very* active development,
    not even an alpha release! 
 
+MC/DC is machine portable and is validated to run on:
+* linux-64 (x86)
+* osx-64 (x86, intel based macs)
+* osx-arm64 (apple silicon based macs)
+* linux-ppc64 (IBM POWER9)
+* linux-nvidia-cuda
+* linux-amd-gcn
+* win-64 (runs but not recommend!)
+
 
 .. only:: html
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -13,7 +13,7 @@ Creating an MC/DC Conda environment
 
 `Conda <https://conda.io/en/latest/>`_ is an open source package and environment management system 
 that runs on Windows, macOS, and Linux. It allows for easy installing and switching between multiple
-versions of software packages and their dependendencies. 
+versions of software packages and their dependencies. 
 We can't force you to use it, but we do *highly* recommend it, particularly
 if you plan on running MC/DC in `numba mode <https://numba.pydata.org/>`_.
 **The included installation script will fail if executed outside of a conda environment.**
@@ -87,12 +87,12 @@ On local machines, mpi4py will be installed using conda,
 To confirm that everything is properly installed, execute ``pytest`` from the MCDC directory. 
 
 ------------------------------------
-Configuring Continous Energy Library
+Configuring Continuous Energy Library
 ------------------------------------
 
-MC/DC has continous energy transport capibilities.
-We provide the library and easy install to members of CEMeNT and other close devlopers.
-Due to export contorls we cannot build a library and transport functinoality in a single source.
+MC/DC has continuous energy transport capabilities.
+We provide the library and easy install to members of CEMeNT and other close developers.
+Due to export controls we cannot build a library and transport functionality in a single source.
 If you are a member of CEMeNT you should have access to `this internal repo <https://github.com/CEMeNT-PSAAP/MCDC-Xsec>`_.
 You an then either set a flag in the install script like,
 
@@ -100,11 +100,11 @@ You an then either set a flag in the install script like,
 
     bash install.sh --config_cont_lib
 
-or run the script after instilation as a stand alone operation with
+or run the script after instillation as a stand alone operation with
 
 .. code-block:: sh
 
     bash config_cont_energy.sh
 
-Both these operations will clone the internal directory to your MCDC directory, untar the compressed folder, then set an enviroment variable in your bash script.
+Both these operations will clone the internal directory to your MCDC directory, untar the compressed folder, then set an environment variable in your bash script.
 NOTE: this does assume you are using bash shell.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -86,4 +86,25 @@ On local machines, mpi4py will be installed using conda,
 
 To confirm that everything is properly installed, execute ``pytest`` from the MCDC directory. 
 
+------------------------------------
+Configuring Continous Energy Library
+------------------------------------
 
+MC/DC has continous energy transport capibilities.
+We provide the library and easy install to members of CEMeNT and other close devlopers.
+Due to export contorls we cannot build a library and transport functinoality in a single source.
+If you are a member of CEMeNT you should have access to `this internal repo <https://github.com/CEMeNT-PSAAP/MCDC-Xsec>`_.
+You an then either set a flag in the install script like,
+
+.. code-block:: sh
+
+    bash install.sh --config_cont_lib
+
+or run the script after instilation as a stand alone operation with
+
+.. code-block:: sh
+
+    bash config_cont_energy.sh
+
+Both these operations will clone the internal directory to your MCDC directory, untar the compressed folder, then set an enviroment variable in your bash script.
+NOTE: this does assume you are using bash shell.

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,8 @@ pip install -e .
 
 
 # Install MC/DC dependencies, reply "y" to conda prompt
-conda install numpy numba matplotlib scipy h5py pytest colorama ngsolve distinctipy <<< "y"
-
+conda install numpy numba matplotlib scipy h5py pytest colorama <<< "y"
+pip install ngsolve distinctipy
 
 # Patch numba
 s=$(python -c 'import numba; print(numba.__path__[0])')

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ pip install -e .
 
 # Install MC/DC dependencies, reply "y" to conda prompt
 conda install numpy numba matplotlib scipy h5py pytest colorama <<< "y"
+
+# Installing visualization dependencies (required from pip for osx-arm54)
 pip install ngsolve distinctipy
 
 # Patch numba

--- a/install.sh
+++ b/install.sh
@@ -57,4 +57,3 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,10 @@ while [ $# -gt 0 ]; do
       python setup.py install
       cd ../../
       rm -rf installs/
+      ;;
+
+    --config_cont_lib)
+      bash config_cont_energy.sh
   ;;
   esac
   shift


### PR DESCRIPTION
This probably should have been multiple PRs but oh well.

# New features:
- Testing refactor: Adds osx64 testing target (in-conjunction with linux64), splits regression test into multiple runners to make it go faster! See issue #126 *all the same tests are running*
- Adding some new documentation to generally describe the contribution process to MC/DC
- Continuous energy config: Runs a separate bash script that can be individually launched. To run must be part of the cement center

There are no new dependence, physics, or CS back ends