### PR TITLE
Minor bug in install.sh 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ bash patch_numba.sh
 
 # Install or build mpi4py
 if [ $# -eq 0 ]; then
-  conda mpi4py <<< "y"
+  conda install mpi4py <<< "y"
 fi
 while [ $# -gt 0 ]; do
   case $1 in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 description = "Monte Carlo / Dynamic Code, a pure python high performance Monte Carlo neutronics package"
 readme = "README.md"
-requires-python = ">=3.9, <=3.11.8"
+requires-python = ">=3.9, <=3.12.2"
 license = {file = "LICENSE"}
 keywords = ["Monte Carlo", "Nuclear", "GPU", "numba", "mpi4py", "neutron transport", "neutronics", "HPC"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 description = "Monte Carlo / Dynamic Code, a pure python high performance Monte Carlo neutronics package"
 readme = "README.md"
-requires-python = ">=3.9, <=3.12.2"
+requires-python = ">=3.9, <=3.11.8"
 license = {file = "LICENSE"}
 keywords = ["Monte Carlo", "Nuclear", "GPU", "numba", "mpi4py", "neutron transport", "neutronics", "HPC"]
 classifiers = [


### PR DESCRIPTION
At some point, we accidentally removed `install` from `conda install mpi4py`.
Is it possible to test `install.sh` as part of the github workflow?