### PR TITLE
Add python version check to install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Check python version
+if ! { python3 -c 'import sys; assert sys.version_info < (3,12)' > /dev/null 2>&1 && python3 -c 'import sys; assert sys.version_info >= (3,9)' > /dev/null 2>&1; }; then
+  v=$(python3 --version)
+  p=$(which python)
+  echo "ERROR: Python version must be < 3.12 and >= 3.9."
+  echo "    Found $v at $p."
+  echo "ERROR: Installation failed."
+  exit 1
+fi 
 
 # Install MC/DC module
 pip install -e .

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ bash patch_numba.sh
 
 # Install or build mpi4py
 if [ $# -eq 0 ]; then
-  conda mpi4py <<< "y"
+  conda install mpi4py <<< "y"
 fi
 while [ $# -gt 0 ]; do
   case $1 in

--- a/install.sh
+++ b/install.sh
@@ -10,18 +10,6 @@ if ! { python3 -c 'import sys; assert sys.version_info < (3,12)' > /dev/null 2>&
   exit 1
 fi 
 
-# Install MC/DC module
-pip install -e .
-
-
-# Install MC/DC dependencies, reply "y" to conda prompt
-conda install numpy numba matplotlib scipy h5py pytest colorama <<< "y"
-
-# Installing visualization dependencies (required via pip for osx-arm64)
-pip install ngsolve distinctipy
-
-bash patch_numba.sh
-
 # Install or build mpi4py
 if [ $# -eq 0 ]; then
   conda install mpi4py <<< "y"
@@ -52,4 +40,16 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+# Install MC/DC module
+pip install -e .
+
+
+# Install MC/DC dependencies, reply "y" to conda prompt
+conda install numpy numba matplotlib scipy h5py pytest colorama <<< "y"
+
+# Installing visualization dependencies (required via pip for osx-arm64)
+pip install ngsolve distinctipy
+
+bash patch_numba.sh
 


### PR DESCRIPTION
In what is now line 27 (was line 18), the word 'install' was removed in commit 650d73c; I added that back. I also added a version check. 

We have the pip installation which is cleaner and definitely suggested for general use. The installation script is useful when trying to debug source code, so I'd still like to keep it up-to-date.