### PR TITLE
Domain Decomposition Revamped

### DIFF
--- a/examples/fixed_source/slab_reed_dd/input.py
+++ b/examples/fixed_source/slab_reed_dd/input.py
@@ -44,11 +44,8 @@ mcdc.source(z=[5.0, 6.0], isotropic=True, prob=0.5)
 
 mcdc.tally(scores=["flux"], z=np.linspace(0.0, 8.0, 81))
 
-
 # Setting
-mcdc.setting(N_particle=1000000,caching=False)
-mcdc.domain_decomposition(z=np.linspace(0.0, 8.0, 5),exchange_rate=100000)
+mcdc.setting(N_particle=5000)
+mcdc.domain_decomposition(z=np.linspace(0.0, 8.0, 5))
 # Run
 mcdc.run()
-
-

--- a/examples/fixed_source/slab_reed_dd/input.py
+++ b/examples/fixed_source/slab_reed_dd/input.py
@@ -44,8 +44,11 @@ mcdc.source(z=[5.0, 6.0], isotropic=True, prob=0.5)
 
 mcdc.tally(scores=["flux"], z=np.linspace(0.0, 8.0, 81))
 
+
 # Setting
-mcdc.setting(N_particle=50000)
-mcdc.domain_decomposition(z=np.linspace(0.0, 8.0, 5),exchange_rate=200)
+mcdc.setting(N_particle=1000000,caching=False)
+mcdc.domain_decomposition(z=np.linspace(0.0, 8.0, 5),exchange_rate=100000)
 # Run
 mcdc.run()
+
+

--- a/mcdc/input_.py
+++ b/mcdc/input_.py
@@ -1417,9 +1417,9 @@ def domain_decomposition(
     z : array_like[float], optional
         Location of subdomain boundaries in z (default None).
     exchange_rate : float, optional
-        number of particles to acumulate in the domain banks before sending.
+        Number of particles to acumulate in the domain banks before sending.
     work_ratio : array_like[integer], optional
-        Inte
+        Number of processors in each domain
 
     Returns
     -------

--- a/mcdc/input_.py
+++ b/mcdc/input_.py
@@ -1401,7 +1401,7 @@ def domain_decomposition(
     x=None,
     y=None,
     z=None,
-    exchange_rate=100,
+    exchange_rate=100000,
     work_ratio=None,
     repro=True,
 ):

--- a/mcdc/input_.py
+++ b/mcdc/input_.py
@@ -1428,7 +1428,6 @@ def domain_decomposition(
     """
     card = mcdc.input_deck.technique
     card["domain_decomposition"] = True
-    card["domain_bank_size"] = int(1e5)
     card["dd_exchange_rate"] = int(exchange_rate)
     card["dd_repro"] = repro
     dom_num = 1

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -146,6 +146,9 @@ def dd_signal_block(mcdc):
     if rank == 0:
         mcdc["domain_decomp"]["send_total"] += send_delta
         mcdc["domain_decomp"]["busy_total"] -= 1
+        send_total = mcdc["domain_decomp"]["send_total"]
+        busy_total = mcdc["domain_decomp"]["busy_total"]
+        print(f"BUSY {busy_total} SENT {send_total}",flush=True)
         if (mcdc["domain_decomp"]["busy_total"] == 0) and (mcdc["domain_decomp"]["send_total"] == 0):
             dd_signal_halt(mcdc)
     else:
@@ -166,6 +169,9 @@ def dd_signal_unblock(mcdc):
     if rank == 0:
         mcdc["domain_decomp"]["send_total"] += send_delta
         mcdc["domain_decomp"]["busy_total"] += 1
+        send_total = mcdc["domain_decomp"]["send_total"]
+        busy_total = mcdc["domain_decomp"]["busy_total"]
+        print(f"BUSY {busy_total} SENT {send_total}",flush=True)
         if (mcdc["domain_decomp"]["busy_total"] == 0) and (mcdc["domain_decomp"]["send_total"] == 0):
             dd_signal_halt(mcdc)
     else:
@@ -183,6 +189,9 @@ def dd_handle_event(event,mcdc):
     if event['type'] == 'turnstile':
         mcdc["domain_decomp"]["send_total"] += event['send_delta']
         mcdc["domain_decomp"]["busy_total"] += event['busy_delta']
+        send_total = mcdc["domain_decomp"]["send_total"]
+        busy_total = mcdc["domain_decomp"]["busy_total"]
+        print(f"BUSY {busy_total} SENT {send_total}",flush=True)
         if (mcdc["domain_decomp"]["busy_total"] == 0) and (mcdc["domain_decomp"]["send_total"] == 0):
             dd_signal_halt(mcdc)
     elif event['type'] == 'halt':
@@ -322,6 +331,7 @@ def dd_particle_receive(mcdc):
         if mcdc["domain_decomp"]["rank_busy"]:
             dd_signal_block(mcdc)
             mcdc["domain_decomp"]["rank_busy"] = False
+            print(f"Rank {MPI.COMM_WORLD.Get_rank()} no longer busy")
 
 
         buf = MPI.COMM_WORLD.recv()
@@ -339,6 +349,7 @@ def dd_particle_receive(mcdc):
         if mcdc["domain_decomp"]["recv_count"] > 0 and not mcdc["domain_decomp"]["rank_busy"]:
             dd_signal_unblock(mcdc)
             mcdc["domain_decomp"]["rank_busy"] = True
+            print(f"Rank {MPI.COMM_WORLD.Get_rank()} busy")
 
         size = bankr.shape[0]
         # Set output buffer

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -1217,11 +1217,11 @@ def bank_rebalance(mcdc):
         # Send
         if more_left:
             n = work_start - idx_start
-            request_left = MPI.COMM_WORLD.send(bank[:n], dest=left)
+            request_left = MPI.COMM_WORLD.isend(bank[:n], dest=left)
             bank = bank[n:]
         if more_right:
             n = idx_end - work_end
-            request_right = MPI.COMM_WORLD.send(bank[-n:], dest=right)
+            request_right = MPI.COMM_WORLD.isend(bank[-n:], dest=right)
             bank = bank[:-n]
 
         # Receive

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -237,6 +237,7 @@ def loop_source(seed, mcdc):
                 print_progress(percent, mcdc)
 
     if mcdc["technique"]["domain_decomposition"]:
+        print("TEST")
         kernel.dd_check_in(mcdc)
         kernel.dd_particle_send(mcdc)
         terminated = False

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -25,8 +25,6 @@ from mcdc.print_ import (
 caching = True
 
 
-
-
 def set_cache(setting):
     caching = setting
 
@@ -82,7 +80,7 @@ def loop_fixed_source(mcdc):
                 # TODO: Output tally (optional)
 
                 # Manage particle banks: population control and work rebalance
-                seed_bank = kernel.split_seed(seed_census,SEED_SPLIT_BANK)
+                seed_bank = kernel.split_seed(seed_census, SEED_SPLIT_BANK)
                 kernel.manage_particle_banks(seed_bank, mcdc)
 
         # Multi-batch closeout
@@ -104,10 +102,6 @@ def loop_fixed_source(mcdc):
         kernel.uq_tally_closeout(mcdc)
     else:
         kernel.tally_closeout(mcdc)
-
-
-
-
 
 
 # =========================================================================
@@ -154,8 +148,6 @@ def loop_eigenvalue(mcdc):
 # =============================================================================
 
 
-
-
 @njit(cache=caching)
 def loop_source(seed, mcdc):
     # Progress bar indicator
@@ -163,7 +155,6 @@ def loop_source(seed, mcdc):
 
     if mcdc["technique"]["domain_decomposition"]:
         kernel.dd_check_in(mcdc)
-
 
     # Loop over particle sources
     work_start = mcdc["mpi_work_start"]
@@ -299,8 +290,6 @@ def loop_source(seed, mcdc):
             if kernel.dd_check_halt(mcdc):
                 kernel.dd_check_out(mcdc)
                 terminated = True
-
-
 
 
 # =========================================================================

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -155,6 +155,7 @@ def loop_eigenvalue(mcdc):
 
 
 
+
 @njit(cache=caching)
 def loop_source(seed, mcdc):
     # Progress bar indicator
@@ -254,8 +255,6 @@ def loop_source(seed, mcdc):
         kernel.dd_recv(mcdc)
         if mcdc["domain_decomp"]["work_done"]:
             terminated = True
-            with objmode():
-                print(f"rank {MPI.COMM_WORLD.Get_rank()}",flush=True)
 
         while not terminated:
             if mcdc["bank_active"]["size"] > 0:
@@ -289,11 +288,6 @@ def loop_source(seed, mcdc):
 
             kernel.dd_recv(mcdc)
 
-            if mcdc["domain_decomp"]["work_done"]:
-                with objmode():
-                    print(f"rank {MPI.COMM_WORLD.Get_rank()}",flush=True)
-
-
             # Progress printout
             """
             percent = 1 - work_remaining / max_work
@@ -305,7 +299,6 @@ def loop_source(seed, mcdc):
             if kernel.dd_check_halt(mcdc):
                 kernel.dd_check_out(mcdc)
                 terminated = True
-
 
 
 

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -111,8 +111,6 @@ def run():
     # Print banner, hardware configuration, and header
     print_banner(mcdc)
 
-    print(mcdc["setting"]["caching"])
-
     set_cache(mcdc["setting"]["caching"])
 
     print_msg(" Now running TNT...")
@@ -297,8 +295,11 @@ def prepare():
     type_.make_type_uq_tally(input_deck)
     type_.make_type_uq(input_deck)
     type_.make_type_domain_decomp(input_deck)
+    type_.make_type_dd_turnstile_event(input_deck)
     type_.make_type_technique(input_deck)
     type_.make_type_global(input_deck)
+
+
 
     # =========================================================================
     # Create the global variable container

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -299,8 +299,6 @@ def prepare():
     type_.make_type_technique(input_deck)
     type_.make_type_global(input_deck)
 
-
-
     # =========================================================================
     # Create the global variable container
     #   TODO: Better alternative?

--- a/mcdc/type_.py
+++ b/mcdc/type_.py
@@ -1027,17 +1027,16 @@ def make_type_uq(input_deck):
     )
 
 
-
 def make_type_dd_turnstile_event(input_deck):
     global dd_turnstile_event, dd_turnstile_event_mpi
-    dd_turnstile_event = np.dtype([
-        ("busy_delta", int32),
-        ("send_delta", int32),
-    ])
+    dd_turnstile_event = np.dtype(
+        [
+            ("busy_delta", int32),
+            ("send_delta", int32),
+        ]
+    )
     dd_turnstile_event_mpi = from_numpy_dtype(dd_turnstile_event)
     dd_turnstile_event_mpi.Commit()
-
-
 
 
 def make_type_domain_decomp(input_deck):
@@ -1058,31 +1057,30 @@ def make_type_domain_decomp(input_deck):
         bank_domain_zp = particle_bank(0)
         bank_domain_zn = particle_bank(0)
 
-
     domain_decomp = np.dtype(
         [
             # Info tracked in all ranks
-            ("bank_xp",    bank_domain_xp),
-            ("bank_xn",    bank_domain_xn),
-            ("bank_yp",    bank_domain_yp),
-            ("bank_yn",    bank_domain_yn),
-            ("bank_zp",    bank_domain_zp),
-            ("bank_zn",    bank_domain_zn),
-
-            ("send_count", int64 ), # Number of particles sent
-            ("recv_count", int64 ), # Number of particles recv'd
-            ("rank_busy",  bool_ ), # True if the rank currently has particles to process
-            ("work_done",  int64 ), # Whether or not there is any outstanding work across any ranks
-
+            ("bank_xp", bank_domain_xp),
+            ("bank_xn", bank_domain_xn),
+            ("bank_yp", bank_domain_yp),
+            ("bank_yn", bank_domain_yn),
+            ("bank_zp", bank_domain_zp),
+            ("bank_zn", bank_domain_zn),
+            ("send_count", int64),  # Number of particles sent
+            ("recv_count", int64),  # Number of particles recv'd
+            ("rank_busy", bool_),  # True if the rank currently has particles to process
+            (
+                "work_done",
+                int64,
+            ),  # Whether or not there is any outstanding work across any ranks
             # Info tracked in "leader" rank zero
-            ("send_total", int64 ), # The total number of particles sent but not yet recv'd
-            ("busy_total", int64 ), # The total number of busy ranks
+            (
+                "send_total",
+                int64,
+            ),  # The total number of particles sent but not yet recv'd
+            ("busy_total", int64),  # The total number of busy ranks
         ]
     )
-
-
-
-
 
 
 param_names = ["tag", "ID", "key", "mean", "delta", "distribution", "rng_seed"]

--- a/mcdc/type_.py
+++ b/mcdc/type_.py
@@ -2,6 +2,7 @@ import math, sys, os, h5py
 import numpy as np
 
 from mpi4py import MPI
+from mpi4py.util.dtlib import from_numpy_dtype
 
 # Basic types
 float64 = np.float64
@@ -79,7 +80,7 @@ def make_type_particle(input_deck):
 
 # Particle record (in-bank)
 def make_type_particle_record(input_deck):
-    global particle_record
+    global particle_record, particle_record_mpi
 
     struct = [
         ("x", float64),
@@ -114,6 +115,9 @@ def make_type_particle_record(input_deck):
 
     # Save type
     particle_record = np.dtype(struct)
+
+    particle_record_mpi = from_numpy_dtype(particle_record)
+    particle_record_mpi.Commit()
 
 
 precursor = np.dtype(
@@ -1024,16 +1028,28 @@ def make_type_uq(input_deck):
 
 
 
+def make_type_dd_turnstile_event(input_deck):
+    global dd_turnstile_event, dd_turnstile_event_mpi
+    dd_turnstile_event = np.dtype([
+        ("busy_delta", int32),
+        ("send_delta", int32),
+    ])
+    dd_turnstile_event_mpi = from_numpy_dtype(dd_turnstile_event)
+    dd_turnstile_event_mpi.Commit()
+
+
+
+
 def make_type_domain_decomp(input_deck):
     global domain_decomp
     # Domain banks if needed
     if input_deck.technique["domain_decomposition"]:
-        bank_domain_xp = particle_bank(input_deck.technique["domain_bank_size"])
-        bank_domain_xn = particle_bank(input_deck.technique["domain_bank_size"])
-        bank_domain_yp = particle_bank(input_deck.technique["domain_bank_size"])
-        bank_domain_yn = particle_bank(input_deck.technique["domain_bank_size"])
-        bank_domain_zp = particle_bank(input_deck.technique["domain_bank_size"])
-        bank_domain_zn = particle_bank(input_deck.technique["domain_bank_size"])
+        bank_domain_xp = particle_bank(input_deck.technique["dd_exchange_rate"])
+        bank_domain_xn = particle_bank(input_deck.technique["dd_exchange_rate"])
+        bank_domain_yp = particle_bank(input_deck.technique["dd_exchange_rate"])
+        bank_domain_yn = particle_bank(input_deck.technique["dd_exchange_rate"])
+        bank_domain_zp = particle_bank(input_deck.technique["dd_exchange_rate"])
+        bank_domain_zn = particle_bank(input_deck.technique["dd_exchange_rate"])
     else:
         bank_domain_xp = particle_bank(0)
         bank_domain_xn = particle_bank(0)

--- a/test/regression/run.py
+++ b/test/regression/run.py
@@ -111,7 +111,7 @@ for i, name in enumerate(names):
     answer = h5py.File("answer.h5", "r")
 
     runtimes[-1] = output["runtime/total"][()]
-    print("  (%.2f seconds)" % runtimes[-1])
+    print("  (%.2f seconds)" % runtimes[-1][0])
 
     # Compare all scores
     for score in [key for key in output["tally"].keys() if key != "grid"]:


### PR DESCRIPTION
Revised domain decomposition functionality to:

- use non-pickled API (`Isends`/`Recv` in place of `isend`/`recv`), which should allow for more particles per send/receive transaction. This refactor required:
  - Adding two additional types to `type_`, which are MPI representations of `type_.particle_record` and of a new "turnstile event", which is used to coordinate halting. This is necessary, since the non-pickled API can only handle custom types when given MPI representations of those types.
  - Adding a global variable *outside of object mode*, called `requests`, which contains a list of request/buffer pairs. This is necessary because `objmode` frees the memory associated with all local variables, regardless of outstanding references, and asynchronous sends need their corresponding request object and message buffer to persist until they are complete. Since `objmode` also disallows direct global variable access, requests and buffers are passed to a full Python (non-object mode) function, which then handles storage of outstanding requests and cleanup of resolved requests.
- coordinate/detect halting conditions without the use of collective operations, which should allow ranks to exchange work without requiring synchronization with all other ranks. This is achieved through the addition of two new message types (in addition to the messages that simply transfer particles - which now has `tag=1`).
  - `dd_turnstile_event` messages (`tag=2`), which communicate a `busy_delta` and `send_delta`, which respectively represent changes to the number of ranks that are occupied with work and the number of particles that have been sent but not received. This message type is only sent to rank zero, which acts as custodian to `busy_total` and `send_total` values, representing the counts affected by these deltas. Once both of these counts reach zero as part of the same transaction, rank zero notifies all other ranks that the system has reached a halting condition. Rank zero does not send this message type to itself, instead directly updating the count when necessary.
  - `halt` messages (`tag=3`), which communicate that a halting condition has been reached, and which is sent out  by rank zero to all other ranks once the aforementioned halting condition has been reached.
- use an all-purpose `dd_distribute_bank` function, which de-duplicates the bank-sending logic performed along each cardinal direction.
- use `dd_check_in` and `dd_check_out` functions, that set up and close out the global state required to coordinate halting and clean up outstanding request objects.
- store numba-mode-compatible domain-decomposition-related information in a newly created `domain_decomp` field of the `type_.global_` type.