### PR TITLE
Bug fix: particles sourced on cell boundaries

### DIFF
--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -1724,7 +1724,7 @@ def region_check(P, region, trans, mcdc):
         if positive_side:
             if side > 0.0:
                 return True
-        elif side < 0.0:
+        elif side <= 0.0:
             return True
 
         return False


### PR DESCRIPTION
In the updated CSG functions a `particle is lost` error occurred if a particle was sourced exactly on a cell boundary. In standard Monte Carlo, this bug may never surface but samples in iQMC hit these boundaries quite often. 

In short, replacing `=` with `<=` in `region_check()` returns the same cell ID  as was calculated before the updates.