### PR TITLE
Fixed readthedocs build bugs.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 MOCK_MODULES = ["mpi4py", "colorama", "mpi4py.util.dtlib", "sympy", "matplotlib.pyplot"]
 sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)
 from mpi4py import MPI
+
 MPI.COMM_WORLD.Get_size.return_value = 1
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,9 +18,10 @@ sys.path.insert(0, os.path.abspath("../.."))
 # On Read the Docs, need to mock any python packages that would require c
 from unittest.mock import MagicMock
 
-MOCK_MODULES = ["mpi4py", "colorama", "mpi4py.util.dtlib"]
+MOCK_MODULES = ["mpi4py", "colorama", "mpi4py.util.dtlib", "sympy", "matplotlib.pyplot"]
 sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)
-
+from mpi4py import MPI
+MPI.COMM_WORLD.Get_size.return_value = 1
 
 # -- Project information -----------------------------------------------------
 

--- a/mcdc/__init__.py
+++ b/mcdc/__init__.py
@@ -32,4 +32,5 @@ from mcdc.main import (
     visualize,
 )
 
-__version__ = importlib.metadata.version("mcdc")
+# Temporarily commenting out so docs will build
+# __version__ = importlib.metadata.version("mcdc")


### PR DESCRIPTION
Added sympy, matplotlib.pyplot, and mpi4py.MPI.Get_size.return_value to MagicMock. Also had to remove importlib.metadata.version call from mcdc/__init__.py for now, as readthedocs cannot find mcdc's metadata for some reason.