### PR TITLE
Improve mesh tally scoring

### DIFF
--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -1845,7 +1845,7 @@ def score_mesh_tally(P_arr, distance, tally, data, mcdc):
 
     # Sweep through the distance
     distance_swept = 0.0
-    while distance_swept < distance:
+    while distance_swept < distance - COINCIDENCE_TOLERANCE:
         # Find distances to the mesh grids
         if ux == 0.0:
             dx = INF


### PR DESCRIPTION
This improves some accidental inefficiency. Previously, we always trace the meshes all the way to the problem boundary, even beyond where the particle stops. This is due to the mesh tally scoring function that does not anticipate the new geometry coincidence treatment.