### PR TITLE
CI Ubuntu Version Static set to 22.04

### DIFF
--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"]
+            os: ["ubuntu-22.04"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
         id-token: write
     steps: 

--- a/.github/workflows/regression_test-numba_cpu.yml
+++ b/.github/workflows/regression_test-numba_cpu.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"]
+            os: ["ubuntu-22.04"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/regression_test-numba_cpu_mpi.yml
+++ b/.github/workflows/regression_test-numba_cpu_mpi.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"]
+            os: ["ubuntu-22.04"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/regression_test-python.yml
+++ b/.github/workflows/regression_test-python.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"]
+            os: ["ubuntu-22.04"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/regression_test-python_mpi.yml
+++ b/.github/workflows/regression_test-python_mpi.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"] #, "macos-latest"
+            os: ["ubuntu-22.04"] #, "macos-latest"
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"]
+            os: ["ubuntu-22.04"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11

--- a/.github/workflows/verification_man_mpi_numba.yml
+++ b/.github/workflows/verification_man_mpi_numba.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest"] #, "macos-latest"
+            os: ["ubuntu-22.04"] #, "macos-latest"
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.11


### PR DESCRIPTION
Fix to MPI Issues raised in #267. `ubuntu-latest` mpiach implementation in the github runner is the actual issue [see](https://github.com/mpi4py/setup-mpi/issues/13).

This PR fixes this by changing changing ubuntu version from `ubuntu-latest` which automatically snags the newest one and sets it to static at `ubuntu-22.04` this should probably be updated as we go thru version releases and potentially reverted in the future when this issue is fixed.