### PR TITLE
Prevent eigenvalue tallies from trying to access nu_d data for nuclides without it. Fixes #278

### DIFF
--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -3286,7 +3286,6 @@ def get_nu_group(type_, nuclide, E, group):
         return tot
 
     if type_ == NU_FISSION_DELAYED and group != -1:
-
         return get_XS(
             nuclide["ce_nu_d"][group], E, nuclide["E_nu_d"], nuclide["NE_nu_d"]
         )

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2091,6 +2091,8 @@ def eigenvalue_tally(P_arr, distance, mcdc):
             for i in range(material["N_nuclide"]):
                 ID_nuclide = material["nuclide_IDs"][i]
                 nuclide = mcdc["nuclides"][ID_nuclide]
+                if nuclide["NE_nu_d"] == 0:
+                    continue
                 for j in range(J):
                     nu_d = get_nu_group(NU_FISSION_DELAYED, nuclide, E, j)
                     decay = nuclide["ce_decay"][j]
@@ -3284,6 +3286,7 @@ def get_nu_group(type_, nuclide, E, group):
         return tot
 
     if type_ == NU_FISSION_DELAYED and group != -1:
+
         return get_XS(
             nuclide["ce_nu_d"][group], E, nuclide["E_nu_d"], nuclide["NE_nu_d"]
         )


### PR DESCRIPTION
I added a condition to the eigenvalue_tally() function trying to calculate something with the nu_d data.

This makes the simulations run when the active cycles get enabled on a problem with non fissile materials.

Ilham should take a look at this to make sure that ignoring this step doesn't break the physics somehow since I don't quite understand what is being added up here in the "total" variable. From what I can tell, it should still be 0 if there is no delayed neutron data.