### PR TITLE
update dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,11 @@ classifiers = [
     'Operating System :: MacOS',
 ]
 dependencies = [
-    "numba>0.60.0",
+    "numba>=0.60.0",
     "numpy",
     "scipy",
     "matplotlib",
-    "mpi4py>=3.1.5",
+    "mpi4py>=3.1.4",
     "pytest",
     "h5py",
     "colorama",


### PR DESCRIPTION
Numba 0.60.0 and MPI4Py 3.1.4 seem to work the most for the platforms we have used so far.

What do you think, @jpmorgan98?