### PR TITLE
Refactoring kernel.py's tally_accumulate function for potential 3x speedup on pure Python

### DIFF
--- a/examples/fixed_source/slab_absorbium_profiling/input.py
+++ b/examples/fixed_source/slab_absorbium_profiling/input.py
@@ -1,0 +1,60 @@
+import numpy as np
+import time
+import cProfile, pstats
+
+import mcdc
+
+
+def build_model(N_particle):
+    # materials
+    m1 = mcdc.material(capture=np.array([1.0]))
+    m2 = mcdc.material(capture=np.array([1.5]))
+    m3 = mcdc.material(capture=np.array([2.0]))
+
+    # surfaces
+    s1 = mcdc.surface("plane-z", z=0.0, bc="vacuum")
+    s2 = mcdc.surface("plane-z", z=2.0)
+    s3 = mcdc.surface("plane-z", z=4.0)
+    s4 = mcdc.surface("plane-z", z=6.0, bc="vacuum")
+
+    # cells
+    mcdc.cell(+s1 & -s2, m2)
+    mcdc.cell(+s2 & -s3, m3)
+    mcdc.cell(+s3 & -s4, m1)
+
+    # source
+    mcdc.source(z=[0.0, 6.0], isotropic=True)
+
+    # tally
+    mcdc.tally.mesh_tally(
+        scores=["flux"],
+        z=np.linspace(0.0, 6.0, 61),
+        mu=np.linspace(-1.0, 1.0, 32 + 1),
+    )
+
+    # settings
+    mcdc.setting(N_particle=N_particle)
+
+
+def run_once():
+    t0 = time.perf_counter()
+    mcdc.run()
+    return time.perf_counter() - t0
+
+
+if __name__ == "__main__":
+    # warm-up JIT compiler
+    build_model(200)
+    _ = run_once()
+
+    # use warmed-up JIT compiler
+    build_model(1e3)
+    pr = cProfile.Profile()
+    pr.enable()
+    wall = run_once()
+    pr.disable()
+    print(f"Wall time (profiled run): {wall:.3f} s")
+
+    # output top 25 cumulative time offenders from results of cProfile
+    p = pstats.Stats(pr).sort_stats("cumulative")
+    p.print_stats(25)

--- a/examples/fixed_source/slab_absorbium_profiling/input.py
+++ b/examples/fixed_source/slab_absorbium_profiling/input.py
@@ -48,13 +48,36 @@ if __name__ == "__main__":
     _ = run_once()
 
     # use warmed-up JIT compiler
-    build_model(1e3)
-    pr = cProfile.Profile()
-    pr.enable()
-    wall = run_once()
-    pr.disable()
-    print(f"Wall time (profiled run): {wall:.3f} s")
+    profiling = False
+    if profiling:
+        build_model(1e4)
 
-    # output top 25 cumulative time offenders from results of cProfile
-    p = pstats.Stats(pr).sort_stats("cumulative")
-    p.print_stats(25)
+        pr = cProfile.Profile()
+        pr.enable()
+        wall = run_once()
+        pr.disable()
+
+        # output top 25 cumulative time offenders from results of cProfile
+        p = pstats.Stats(pr).sort_stats("cumulative")
+        p.print_stats(25)
+    else:
+        runs = 20
+        runtimes = []
+        for _ in range(runs):
+            build_model(1e4)
+            runtimes.append(run_once())
+        print(
+            f"mean +/- stdev runtime for {runs} runs: {np.mean(runtimes):.3f} +/- {np.std(runtimes):.3f}"
+        )
+
+        # 1e3
+        # new, no Numba: 0.712s +/- 0.056s
+        # new, Numba: 0.302s +/- 0.077s
+        # old, no Numba: 2.072s +/- 0.046s
+        # old, Numba: 0.329s +/- 0.074
+
+        # 1e4
+        # new, no Numba: 6.125s +/- 0.088s
+        # new, Numba: 1.989s +/- 0.106s
+        # old, no Numba: 20.278s +/- 1.141s
+        # old, Numba: 2.167s +/- 0.088s

--- a/examples/fixed_source/slab_absorbium_profiling/process.py
+++ b/examples/fixed_source/slab_absorbium_profiling/process.py
@@ -1,0 +1,74 @@
+import matplotlib.pyplot as plt
+import h5py
+import numpy as np
+
+from reference import reference
+
+
+# Load results
+with h5py.File("output.h5", "r") as f:
+    print(f.keys())
+    z = f["tallies/mesh_tally_0/grid/z"][:]
+    dz = z[1:] - z[:-1]
+    z_mid = 0.5 * (z[:-1] + z[1:])
+
+    mu = f["tallies/mesh_tally_0/grid/mu"][:]
+    dmu = mu[1:] - mu[:-1]
+    mu_mid = 0.5 * (mu[:-1] + mu[1:])
+
+    psi = f["tallies/mesh_tally_0/flux/mean"][:]
+    psi_sd = f["tallies/mesh_tally_0/flux/sdev"][:]
+    psi = np.transpose(psi)
+    psi_sd = np.transpose(psi_sd)
+
+I = len(z) - 1
+N = len(mu) - 1
+
+# Scalar flux
+phi = np.zeros(I)
+phi_sd = np.zeros(I)
+for i in range(I):
+    phi[i] += np.sum(psi[i, :])
+    phi_sd[i] += np.linalg.norm(psi_sd[i, :])
+
+# Normalize
+phi /= dz
+phi_sd /= dz
+for n in range(N):
+    psi[:, n] = psi[:, n] / dz / dmu[n]
+    psi_sd[:, n] = psi_sd[:, n] / dz / dmu[n]
+
+# Reference solution
+phi_ref, _, psi_ref = reference(z, mu)
+
+# Flux - spatial average
+plt.plot(z_mid, phi, "-b", label="MC")
+plt.fill_between(z_mid, phi - phi_sd, phi + phi_sd, alpha=0.2, color="b")
+plt.plot(z_mid, phi_ref, "--r", label="Ref.")
+plt.xlabel(r"$z$, cm")
+plt.ylabel("Flux")
+plt.ylim([0.06, 0.16])
+plt.grid()
+plt.legend()
+plt.title(r"$\bar{\phi}_i$")
+plt.show()
+
+# Angular flux - spatial average
+vmin = min(np.min(psi_ref), np.min(psi))
+vmax = max(np.max(psi_ref), np.max(psi))
+fig, ax = plt.subplots(1, 2, sharey=True)
+Z, MU = np.meshgrid(z_mid, mu_mid)
+im = ax[0].pcolormesh(MU.T, Z.T, psi_ref, vmin=vmin, vmax=vmax)
+ax[0].set_xlabel(r"Polar cosine, $\mu$")
+ax[0].set_ylabel(r"$z$")
+ax[0].set_title(r"\psi")
+ax[0].set_title(r"$\bar{\psi}_i(\mu)$ [Ref.]")
+ax[1].pcolormesh(MU.T, Z.T, psi, vmin=vmin, vmax=vmax)
+ax[1].set_xlabel(r"Polar cosine, $\mu$")
+ax[1].set_ylabel(r"$z$")
+ax[1].set_title(r"$\bar{\psi}_i(\mu)$ [MC]")
+fig.subplots_adjust(right=0.8)
+cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
+cbar = fig.colorbar(im, cax=cbar_ax)
+cbar.set_label("Angular flux")
+plt.show()

--- a/examples/fixed_source/slab_absorbium_profiling/reference.py
+++ b/examples/fixed_source/slab_absorbium_profiling/reference.py
@@ -1,0 +1,130 @@
+import numpy as np
+from scipy.integrate import quad
+
+
+def reference(x, mu):
+    dx = x[1:] - x[:-1]
+    dmu = mu[1:] - mu[:-1]
+    I = len(x) - 1
+    N = len(mu) - 1
+
+    # Parameters
+    SigmaT3 = 1.0
+    SigmaT1 = 1.5
+    SigmaT2 = 2.0
+    q1 = 1.0 / 6.0 / 2
+    q2 = 1.0 / 6.0 / 2
+    q3 = 1.0 / 6.0 / 2
+    x1 = 2.0
+    x2 = 4.0
+    x3 = 6.0
+    tau1 = SigmaT1 * x1
+    tau2 = SigmaT2 * (x2 - x1)
+    tau3 = SigmaT3 * (x3 - x2)
+
+    # Angular flux
+    def psi1(mu, x):
+        if mu > 0.0:
+            return q1 / SigmaT1 * (1.0 - np.exp(-SigmaT1 * x / mu))
+        elif mu < 0.0:
+            return (psi2(mu, x1) - q1 / SigmaT1) * np.exp(
+                -SigmaT1 * (x1 - x) / np.abs(mu)
+            ) + q1 / SigmaT1
+
+    def psi2(mu, x):
+        if mu > 0.0:
+            return (psi1(mu, x1) - q2 / SigmaT2) * np.exp(
+                -SigmaT2 * (x - x1) / mu
+            ) + q2 / SigmaT2
+        elif mu < 0.0:
+            return (psi3(mu, x2) - q2 / SigmaT2) * np.exp(
+                -SigmaT2 * (x2 - x) / np.abs(mu)
+            ) + q2 / SigmaT2
+
+    def psi3(mu, x):
+        if mu > 0.0:
+            return (psi2(mu, x2) - q3 / SigmaT3) * np.exp(
+                -SigmaT3 * (x - x2) / mu
+            ) + q3 / SigmaT3
+        elif mu < 0.0:
+            return q3 / SigmaT3 * (1.0 - np.exp(-SigmaT3 * (x3 - x) / np.abs(mu)))
+
+    # Flux
+    def phi1(x):
+        return quad(psi1, -1, 1, args=(x), points=[0.0])[0]
+
+    def phi2(x):
+        return quad(psi2, -1, 1, args=(x), points=[0.0])[0]
+
+    def phi3(x):
+        return quad(psi3, -1, 1, args=(x), points=[0.0])[0]
+
+    # Integrands for current
+    def mu_psi1(mu, x):
+        if mu > 0.0:
+            return mu * psi1(mu, x)
+        elif mu < 0.0:
+            return mu * psi1(mu, x)
+
+    def mu_psi2(mu, x):
+        if mu > 0.0:
+            return mu * psi2(mu, x)
+        elif mu < 0.0:
+            return mu * psi2(mu, x)
+
+    def mu_psi3(mu, x):
+        if mu > 0.0:
+            return mu * psi3(mu, x)
+        elif mu < 0.0:
+            return mu * psi3(mu, x)
+
+    # Current
+    def J1(x):
+        return quad(mu_psi1, -1, 1, args=(x), points=[0.0])[0]
+
+    def J2(x):
+        return quad(mu_psi2, -1, 1, args=(x), points=[0.0])[0]
+
+    def J3(x):
+        return quad(mu_psi3, -1, 1, args=(x), points=[0.0])[0]
+
+    # Angular flux
+    def psi1_(x, mu0, mu1):
+        return quad(psi1, mu0, mu1, args=(x), points=[0.0])[0]
+
+    def psi2_(x, mu0, mu1):
+        return quad(psi2, mu0, mu1, args=(x), points=[0.0])[0]
+
+    def psi3_(x, mu0, mu1):
+        return quad(psi3, mu0, mu1, args=(x), points=[0.0])[0]
+
+    phi = np.zeros(I)
+    psi = np.zeros((I, N))
+    J = np.zeros(I)
+
+    for i in range(int(I / 3)):
+        phi[i] = quad(phi1, x[i], x[i + 1])[0] / dx[i]
+        J[i] = quad(J1, x[i], x[i + 1])[0] / dx[i]
+        for n in range(N):
+            mu0 = mu[n]
+            mu1 = mu[n + 1]
+            psi[i, n] = quad(psi1_, x[i], x[i + 1], args=(mu0, mu1))[0] / dx[i] / dmu[n]
+    for i in range(int(I / 3), int(2 * I / 3)):
+        phi[i] = quad(phi2, x[i], x[i + 1])[0] / dx[i]
+        J[i] = quad(J2, x[i], x[i + 1])[0] / dx[i]
+        for n in range(N):
+            mu0 = mu[n]
+            mu1 = mu[n + 1]
+            psi[i, n] = quad(psi2_, x[i], x[i + 1], args=(mu0, mu1))[0] / dx[i] / dmu[n]
+    for i in range(int(2 * I / 3), I):
+        phi[i] = quad(phi3, x[i], x[i + 1])[0] / dx[i]
+        J[i] = quad(J3, x[i], x[i + 1])[0] / dx[i]
+        for n in range(N):
+            mu0 = mu[n]
+            mu1 = mu[n + 1]
+            psi[i, n] = quad(psi3_, x[i], x[i + 1], args=(mu0, mu1))[0] / dx[i] / dmu[n]
+    for n in range(N):
+        mu0 = mu[n]
+        mu1 = mu[n + 1]
+
+    return phi, J, psi

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -1,7 +1,13 @@
 import h5py, math, numba
 
 from mpi4py import MPI
-from numba import int64, literal_unroll, njit, objmode, uint64, prange
+from numba import (
+    int64,
+    literal_unroll,
+    njit,
+    objmode,
+    uint64,
+)
 
 import mcdc.adapt as adapt
 import mcdc.src.geometry as geometry
@@ -2333,7 +2339,7 @@ def tally_reduce(data, mcdc):
             dd_reduce(data, mcdc)
 
 
-@njit(cache=True, fastmath=True, inline="always")
+@njit
 def tally_accumulate(data, mcdc):
     tally_bin = data[TALLY]
 
@@ -2342,8 +2348,7 @@ def tally_accumulate(data, mcdc):
     sum2 = tally_bin[TALLY_SUM_SQ]
 
     sum_ += score
-    np.multiply(score, score, out=score)
-
+    score *= score
     sum2 += score
     score[:] = 0.0
 

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -1,13 +1,7 @@
 import h5py, math, numba
 
 from mpi4py import MPI
-from numba import (
-    int64,
-    literal_unroll,
-    njit,
-    objmode,
-    uint64,
-)
+from numba import int64, literal_unroll, njit, objmode, uint64, prange
 
 import mcdc.adapt as adapt
 import mcdc.src.geometry as geometry
@@ -2339,19 +2333,19 @@ def tally_reduce(data, mcdc):
             dd_reduce(data, mcdc)
 
 
-@njit
+@njit(cache=True, fastmath=True, inline="always")
 def tally_accumulate(data, mcdc):
     tally_bin = data[TALLY]
-    N_bin = tally_bin.shape[1]
 
-    for i in range(N_bin):
-        # Accumulate score and square of score into sum and sum_sq
-        score = tally_bin[TALLY_SCORE, i]
-        tally_bin[TALLY_SUM, i] += score
-        tally_bin[TALLY_SUM_SQ, i] += score * score
+    score = tally_bin[TALLY_SCORE]
+    sum_ = tally_bin[TALLY_SUM]
+    sum2 = tally_bin[TALLY_SUM_SQ]
 
-        # Reset score bin
-        tally_bin[TALLY_SCORE, i] = 0.0
+    sum_ += score
+    np.multiply(score, score, out=score)
+
+    sum2 += score
+    score[:] = 0.0
 
 
 @njit

--- a/mcdc/kernel.py
+++ b/mcdc/kernel.py
@@ -2353,6 +2353,21 @@ def tally_accumulate(data, mcdc):
     score[:] = 0.0
 
 
+# @njit
+# def tally_accumulate(data, mcdc):
+#     tally_bin = data[TALLY]
+#     N_bin = tally_bin.shape[1]
+
+#     for i in range(N_bin):
+#         # Accumulate score and square of score into sum and sum_sq
+#         score = tally_bin[TALLY_SCORE, i]
+#         tally_bin[TALLY_SUM, i] += score
+#         tally_bin[TALLY_SUM_SQ, i] += score * score
+
+#         # Reset score bin
+#         tally_bin[TALLY_SCORE, i] = 0.0
+
+
 @njit
 def census_based_tally_output(data, mcdc):
     idx_batch = mcdc["idx_batch"]


### PR DESCRIPTION
Hello. I was curious about which parts of the _slab_absorbium_ example contributed the most to the wall clock time of calling `mcdc.run()` and I might have made the pure Python version much faster. Old code is currently temporarily commented out in the commits being PR'd here in case someone wants to verify each. I'm hoping someone could verify my results 🙂

First, I created a copy of the _slab_absorbium_ example in a new directory called _slab_absorbium_profiling_, which uses the cProfile profiler to identify timing bottlenecks. Then I re-wrote the input.py file for this example to examine the runtime of `mcdc.run()` after having first "warmed up" Numba JIT compilation. When I run it for a 200 particle "warm-up simulation" and a 1e3 particle "warmed up simulation" I get the following output (the warm-up isn't necessary here though in pure Python mode) :
![mcdc_outputs_original](https://github.com/user-attachments/assets/d73dba62-cca8-4978-925b-0fa396b0db46)


I also used cProfile to output the top 25 functions that contributed the most to wall clock runtime:
![cProfile_output_original](https://github.com/user-attachments/assets/47317c2f-b6c8-4916-b2b0-10498cf22843)

It's clear from cProfile that the function `tally_accumulate(data, mcdc)` in `kernel.py` contributes significantly to runtime. Notably, the original function leverages a for loop for "Numpy vectorizable" operations. Thus, one one can rewrite the code to circumvent explicit "for looping", yielding faster runtime on pure Python. That change is what this PR commits to the codebase.

I reran the example with the new function and get the following output:
![mcdc_outputs_updated](https://github.com/user-attachments/assets/3f6a1825-42aa-4773-87e0-fe2ad59a78fd)


Additionally, when viewing the new output from cProfile, we see that `tally_accumulate(data, mcdc)` is no longer a significant contributor to runtime:
![cProfile_output_updated](https://github.com/user-attachments/assets/8e2af557-ff5c-475d-bcdc-b6812831c2e5)


Most importantly though, all of the regression tests from the _/MCDC/test/regression_ directory still pass, but it would be nice if someone could verify/validate this updated code too:
![test_results_updated](https://github.com/user-attachments/assets/cfa980bb-df1b-4c49-ab4f-098602b2e4ea)

Also, the output from process.py looks the same:
![process_results_updated](https://github.com/user-attachments/assets/cce0d31f-955f-4f9f-9ee3-25a75ac4e51a)

I then tested the runtime with 1e4 particles too and observe ~3x speedup during pure Python mode and a slight speedup in Numba mode (1e5 isn't plotted here but I observed the same ~3x speedup for pure Python). The text in black is the mean wall clock runtime in seconds; standard deviation bars are plotted yet are too small to see on this log-scale:
<img width="977" height="677" alt="Untitled" src="https://github.com/user-attachments/assets/64a396d3-8eb9-4254-813e-df79b504c622" />


