### PR TITLE
Add neutron inelastic scattering law unit tests

### DIFF
--- a/test/unit/run.py
+++ b/test/unit/run.py
@@ -5,12 +5,20 @@ from pathlib import Path
 root = Path(".")
 paths = root.rglob("*.py")
 
-EXCLUDE = {"run.py", "__pycache__", ".git"}
+EXCLUDE = {"run.py", "__pycache__", ".git", "conftest.py", "__init__.py"}
+EXCLUDE_PREFIX = {"make_test_"}
 
 start = time.perf_counter()
 for path in paths:
+    # Skip exact matches
     if any(part in EXCLUDE for part in path.parts):
         continue
+
+    # Skip if any part starts with any prefix in EXCLUDE_PREFIX
+    PREFIX_TUPLE = tuple(EXCLUDE_PREFIX)
+    if any(part.startswith(PREFIX_TUPLE) for part in path.parts):
+        continue
+
     print(f"\nRunning {str(path)}")
     sys.stdout.flush()
     os.system(f"pytest -q {str(path)}")

--- a/test/unit/transport/distributions/__init__.py
+++ b/test/unit/transport/distributions/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for distribution unit test modules.

--- a/test/unit/transport/distributions/conftest.py
+++ b/test/unit/transport/distributions/conftest.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+
+# Force pure-Python execution for numba in tests.
+os.environ.setdefault("NUMBA_DISABLE_JIT", "1")
+
+import mcdc.transport.distribution as dist
+
+
+class MockRNG:
+    def __init__(self, values):
+        self._values = list(values)
+        self._i = 0
+
+    def lcg(self, _state_container):
+        # MCDC uses dist.rng.lcg(state) as its RNG hook. We override it with this
+        # deterministic sequence so tests can be analytic and reproducible.
+        if self._i >= len(self._values):
+            raise IndexError("MockRNG depleted")
+        value = self._values[self._i]
+        self._i += 1
+        return value
+
+
+@pytest.fixture
+def rng_state():
+    """
+    Return the minimal RNG state container expected by MCDC.
+
+    MCDC passes a list of per-thread state dicts; tests only need one.
+    """
+    return [dict(rng_seed=0)]
+
+
+@pytest.fixture
+def rng_sequence():
+    """
+    Temporarily replace dist.rng.lcg with a deterministic sequence.
+
+    Usage:
+        rng_sequence([0.1, 0.2, 0.3])
+        ... code under test that calls dist.rng.lcg(...)
+    """
+    original_lcg = dist.rng.lcg
+
+    def _apply(values):
+        # Swap in a mock LCG implementation that returns the provided values.
+        rng = MockRNG(values)
+        dist.rng.lcg = rng.lcg
+        return rng
+
+    # Yield a callable to the test, then restore the real RNG after the test ends.
+    yield _apply
+    dist.rng.lcg = original_lcg

--- a/test/unit/transport/distributions/test_data/__init__.py
+++ b/test/unit/transport/distributions/test_data/__init__.py
@@ -1,0 +1,13 @@
+from .make_test_kalbach_mann_data import make_test_kalbach_mann_data
+from .make_test_multi_table_data import make_test_multi_table_data
+from .make_test_table_data_constant import make_test_table_data_constant
+from .make_test_tabulated_data import make_test_tabulated_data
+from .make_test_tabulated_energy_angle_data import make_test_tabulated_energy_angle_data
+
+__all__ = [
+    "make_test_kalbach_mann_data",
+    "make_test_multi_table_data",
+    "make_test_table_data_constant",
+    "make_test_tabulated_data",
+    "make_test_tabulated_energy_angle_data",
+]

--- a/test/unit/transport/distributions/test_data/make_test_kalbach_mann_data.py
+++ b/test/unit/transport/distributions/test_data/make_test_kalbach_mann_data.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+
+def make_test_kalbach_mann_data():
+    # Two incident-energy tables, each with 3 points.
+    Ei = [1.0, 3.0, 5.0]
+    L_i = [0.0, 3.0, 6.0]
+
+    E_i_k = [1.0, 2.0, 3.0, 2.0, 4.0, 6.0]
+    p_i_k = [0.5, 0.5, 0.5, 0.2, 0.2, 0.2]
+    c_i_k = [0.0, 0.5, 1.0, 0.0, 0.2, 1.0]
+
+    # Keep R = 0 and A = 1 for deterministic angular sampling.
+    R = [0.0] * 6
+    A = [1.0] * 6
+
+    data = np.array(
+        Ei + L_i + E_i_k + p_i_k + c_i_k + R + A,
+        dtype=np.float64,
+    )
+
+    idx = 0
+    grid_offset = idx
+    idx += len(Ei)
+    offset_offset = idx
+    idx += len(L_i)
+    energy_out_offset = idx
+    idx += len(E_i_k)
+    pdf_offset = idx
+    idx += len(p_i_k)
+    cdf_offset = idx
+    idx += len(c_i_k)
+    precompound_offset = idx
+    idx += len(R)
+    angular_slope_offset = idx
+
+    kalbach = {
+        "energy_offset": grid_offset,
+        "energy_length": len(Ei),
+        "offset_offset": offset_offset,
+        "offset_length": len(L_i),
+        "energy_out_offset": energy_out_offset,
+        "energy_out_length": len(E_i_k),
+        "pdf_offset": pdf_offset,
+        "pdf_length": len(p_i_k),
+        "cdf_offset": cdf_offset,
+        "cdf_length": len(c_i_k),
+        "precompound_factor_offset": precompound_offset,
+        "precompound_factor_length": len(R),
+        "angular_slope_offset": angular_slope_offset,
+        "angular_slope_length": len(A),
+    }
+    return kalbach, data

--- a/test/unit/transport/distributions/test_data/make_test_multi_table_data.py
+++ b/test/unit/transport/distributions/test_data/make_test_multi_table_data.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+
+def make_test_multi_table_data():
+    # Two incident-energy tables, each with 3 points.
+    Ei = [1.0, 3.0]
+    L_i = [0.0, 3.0]
+
+    E_i_k = [10.0, 20.0, 30.0, 100.0, 200.0, 300.0]
+    p_i_k = [0.1, 0.1, 0.1, 0.01, 0.01, 0.01]
+    c_i_k = [0.0, 0.5, 1.0, 0.0, 0.6, 1.0]
+
+    data = np.array(Ei + L_i + E_i_k + p_i_k + c_i_k, dtype=np.float64)
+
+    idx = 0
+    grid_offset = idx
+    idx += len(Ei)
+    offset_offset = idx
+    idx += len(L_i)
+    value_offset = idx
+    idx += len(E_i_k)
+    pdf_offset = idx
+    idx += len(p_i_k)
+    cdf_offset = idx
+
+    multi_table = {
+        "grid_offset": grid_offset,
+        "grid_length": len(Ei),
+        "offset_offset": offset_offset,
+        "offset_length": len(L_i),
+        "value_offset": value_offset,
+        "value_length": len(E_i_k),
+        "pdf_offset": pdf_offset,
+        "pdf_length": len(p_i_k),
+        "cdf_offset": cdf_offset,
+        "cdf_length": len(c_i_k),
+    }
+    return multi_table, data

--- a/test/unit/transport/distributions/test_data/make_test_table_data_constant.py
+++ b/test/unit/transport/distributions/test_data/make_test_table_data_constant.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from mcdc.constant import INTERPOLATION_LINEAR
+
+
+def make_test_table_data_constant(value=1.0):
+    x = [0.0, 10.0]
+    y = [value, value]
+    data = np.array(x + y, dtype=np.float64)
+    table = {
+        "x_offset": 0,
+        "x_length": len(x),
+        "y_offset": len(x),
+        "y_length": len(y),
+        "interpolation": INTERPOLATION_LINEAR,
+    }
+    return table, data

--- a/test/unit/transport/distributions/test_data/make_test_tabulated_data.py
+++ b/test/unit/transport/distributions/test_data/make_test_tabulated_data.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+
+def make_test_tabulated_data(E_i_k, c_i_k):
+    E_i_k = list(E_i_k)
+    c_i_k = list(c_i_k)
+    data = np.array(E_i_k + c_i_k, dtype=np.float64)
+    table = {
+        "value_offset": 0,
+        "value_length": len(E_i_k),
+        "cdf_offset": len(E_i_k),
+        "cdf_length": len(c_i_k),
+    }
+    return table, data

--- a/test/unit/transport/distributions/test_data/make_test_tabulated_energy_angle_data.py
+++ b/test/unit/transport/distributions/test_data/make_test_tabulated_energy_angle_data.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+
+def make_test_tabulated_energy_angle_data():
+    Ei = [1.0, 3.0, 5.0]
+    L_i = [0.0, 3.0, 6.0]
+
+    E_i_k = [1.0, 2.0, 3.0, 2.0, 4.0, 6.0]
+    p_i_k = [0.5, 0.5, 0.5, 0.2, 0.2, 0.2]
+    c_i_k = [0.0, 0.5, 1.0, 0.0, 0.2, 1.0]
+
+    L_i_k = [0.0, 3.0, 6.0]
+    mu_i_j = [-1.0, 0.0, 1.0, -0.5, 0.5, 1.0]
+    p_mu_i_j = [0.5, 0.5, 0.5, 0.2, 0.2, 0.2]
+    c_mu_i_j = [0.0, 0.5, 1.0, 0.0, 0.3, 1.0]
+
+    data = np.array(
+        Ei
+        + L_i
+        + E_i_k
+        + p_i_k
+        + c_i_k
+        + L_i_k
+        + mu_i_j
+        + p_mu_i_j
+        + c_mu_i_j,
+        dtype=np.float64,
+    )
+
+    idx = 0
+    energy_offset = idx
+    idx += len(Ei)
+    offset_offset = idx
+    idx += len(L_i)
+    energy_out_offset = idx
+    idx += len(E_i_k)
+    pdf_offset = idx
+    idx += len(p_i_k)
+    cdf_offset = idx
+    idx += len(c_i_k)
+    cosine_offset__offset = idx
+    idx += len(L_i_k)
+    cosine_offset = idx
+    idx += len(mu_i_j)
+    cosine_pdf_offset = idx
+    idx += len(p_mu_i_j)
+    cosine_cdf_offset = idx
+
+    table = {
+        "energy_offset": energy_offset,
+        "energy_length": len(Ei),
+        "offset_offset": offset_offset,
+        "offset_length": len(L_i),
+        "energy_out_offset": energy_out_offset,
+        "energy_out_length": len(E_i_k),
+        "pdf_offset": pdf_offset,
+        "pdf_length": len(p_i_k),
+        "cdf_offset": cdf_offset,
+        "cdf_length": len(c_i_k),
+        "cosine_offset__offset": cosine_offset__offset,
+        "cosine_offset__length": len(L_i_k),
+        "cosine_offset": cosine_offset,
+        "cosine_length": len(mu_i_j),
+        "cosine_pdf_offset": cosine_pdf_offset,
+        "cosine_pdf_length": len(p_mu_i_j),
+        "cosine_cdf_offset": cosine_cdf_offset,
+        "cosine_cdf_length": len(c_mu_i_j),
+    }
+    return table, data

--- a/test/unit/transport/distributions/test_data/make_test_tabulated_energy_angle_data.py
+++ b/test/unit/transport/distributions/test_data/make_test_tabulated_energy_angle_data.py
@@ -15,15 +15,7 @@ def make_test_tabulated_energy_angle_data():
     c_mu_i_j = [0.0, 0.5, 1.0, 0.0, 0.3, 1.0]
 
     data = np.array(
-        Ei
-        + L_i
-        + E_i_k
-        + p_i_k
-        + c_i_k
-        + L_i_k
-        + mu_i_j
-        + p_mu_i_j
-        + c_mu_i_j,
+        Ei + L_i + E_i_k + p_i_k + c_i_k + L_i_k + mu_i_j + p_mu_i_j + c_mu_i_j,
         dtype=np.float64,
     )
 

--- a/test/unit/transport/distributions/test_evaporation.py
+++ b/test/unit/transport/distributions/test_evaporation.py
@@ -14,9 +14,7 @@ def test_evaporation_sample(rng_sequence, rng_state):
     xi1, xi2 = 0.1, 0.2
     rng_sequence([xi1, xi2])
 
-    sampled_E = dist.sample_evaporation(
-        2.0, rng_state, evaporation, mcdc, data
-    )
+    sampled_E = dist.sample_evaporation(2.0, rng_state, evaporation, mcdc, data)
     # The constant temperature table gives T(E_in) = 1.0 for this test.
     # With U = 0, the MCNP notation E_in - U becomes 2.0, so
     #   w = (E_in - U) / T(E_in) = 2.0.

--- a/test/unit/transport/distributions/test_evaporation.py
+++ b/test/unit/transport/distributions/test_evaporation.py
@@ -1,0 +1,31 @@
+import math
+
+import mcdc.transport.distribution as dist
+
+from .test_data import make_test_table_data_constant
+
+
+def test_evaporation_sample(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.7 (Law 9: Evaporation Spectrum)
+    table, data = make_test_table_data_constant(1.0)
+    mcdc = {"table_data": [table]}
+    evaporation = {"nuclear_temperature_ID": 0, "restriction_energy": 0.0}
+
+    xi1, xi2 = 0.1, 0.2
+    rng_sequence([xi1, xi2])
+
+    sampled_E = dist.sample_evaporation(
+        2.0, rng_state, evaporation, mcdc, data
+    )
+    # The constant temperature table gives T(E_in) = 1.0 for this test.
+    # With U = 0, the MCNP notation E_in - U becomes 2.0, so
+    #   w = (E_in - U) / T(E_in) = 2.0.
+    w = 2.0
+    # Eq. (2.75) introduces g = 1 - exp(-w) in the normalized truncated spectrum.
+    g = 1.0 - math.exp(-w)
+    # Eq. (2.76) then gives the sampled evaporation energy:
+    #   E_out = -T(E_in) * ln[(1 - g * xi_1) (1 - g * xi_2)].
+    # Since T(E_in) = 1.0 here, the prefactor is omitted in the simplified form below.
+    expected_E = -math.log((1.0 - g * xi1) * (1.0 - g * xi2))
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_kalbach_mann.py
+++ b/test/unit/transport/distributions/test_kalbach_mann.py
@@ -1,0 +1,35 @@
+import math
+
+import mcdc.transport.distribution as dist
+
+from .test_data import make_test_kalbach_mann_data
+
+
+def test_kalbach_mann_sample(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.11 (Law 44: Kalbach-87 Correlated Energy-angle Scattering)
+    kalbach, data = make_test_kalbach_mann_data()
+
+    # For E_in = 2.0 on the grid [1, 3], the interpolation fraction is r = 0.5.
+    # xi_1 = 0.3 < r, so the second energy table is selected.
+    xi1, xi2, xi3, xi4 = 0.3, 0.1, 0.7, 0.5
+    rng_sequence([xi1, xi2, xi3, xi4])
+
+    sampled_E, sampled_mu = dist.sample_kalbach_mann(2.0, rng_state, kalbach, data)
+
+    # Law 44 uses the Law 4 energy construction, so with xi_2 = 0.1 in the first bin
+    # of the selected table:
+    E_min, E_max = 1.5, 4.5
+    E_hat = 2.0 + (xi2 - 0.0) / 0.2
+    # As in the Law 4 tests, the constant bin PDF means Eq. (2.66) collapses to the
+    # simpler Eq. (2.65) interpolation for the sampled E'.
+    expected_E = E_min + (E_hat - 2.0) / (6.0 - 2.0) * (E_max - E_min)
+
+    # Eq. (2.90) and Eq. (2.91): with constant test data, the interpolation is trivial,
+    # so A = 1 and R = 0 at every point.
+    # Since xi_3 = 0.7 > R, Eq. (2.93) and Eq. (2.94) apply:
+    #   T = (2 * xi_4 - 1) * sinh(A) = 0
+    #   mu = ln(T + sqrt(T^2 + 1)) / A = 0
+    expected_mu = 0.0
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    assert math.isclose(sampled_mu, expected_mu, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_level_scattering.py
+++ b/test/unit/transport/distributions/test_level_scattering.py
@@ -1,0 +1,15 @@
+import math
+
+import mcdc.transport.distribution as dist
+
+
+def test_level_scattering_sample():
+    # MCNP Theory & User Manual §2.4.3.5.4.3 (Law 3: Inelastic Scattering from Nuclear Levels)
+    # The implementation stores the Law 3 relation in the linear form
+    #   E_out = C2 * (E_in - C1).
+    # For this test, E_in = 5, C1 = 1, and C2 = 0.5, so
+    #   E_out = 0.5 * (5 - 1) = 2.
+    level = {"C1": 1.0, "C2": 0.5}
+    sampled_E = dist.sample_level_scattering(5.0, level)
+    expected_E = 2.0
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_maxwellian.py
+++ b/test/unit/transport/distributions/test_maxwellian.py
@@ -15,9 +15,7 @@ def test_maxwellian_sample(rng_sequence, rng_state):
     xi1, xi2, xi3 = 0.9, 0.9, 0.0
     rng_sequence([xi1, xi2, xi3])
 
-    sampled_E = dist.sample_maxwellian(
-        2.0, rng_state, maxwellian, mcdc, data
-    )
+    sampled_E = dist.sample_maxwellian(2.0, rng_state, maxwellian, mcdc, data)
     # MCNP Eq. (2.73):
     #   E_out = -T(E_in) * [xi_1^2 / (xi_1^2 + xi_2^2) * ln(xi_3) + ln(xi_4)]
     # MCDC uses the equivalent polar-form reduction

--- a/test/unit/transport/distributions/test_maxwellian.py
+++ b/test/unit/transport/distributions/test_maxwellian.py
@@ -1,0 +1,28 @@
+import math
+
+import mcdc.transport.distribution as dist
+from mcdc.constant import PI
+
+from .test_data import make_test_table_data_constant
+
+
+def test_maxwellian_sample(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.6 (Law 7: Simple Maxwell Fission Spectrum)
+    table, data = make_test_table_data_constant(1.0)
+    mcdc = {"table_data": [table]}
+    maxwellian = {"nuclear_temperature_ID": 0, "restriction_energy": 0.0}
+
+    xi1, xi2, xi3 = 0.9, 0.9, 0.0
+    rng_sequence([xi1, xi2, xi3])
+
+    sampled_E = dist.sample_maxwellian(
+        2.0, rng_state, maxwellian, mcdc, data
+    )
+    # MCNP Eq. (2.73):
+    #   E_out = -T(E_in) * [xi_1^2 / (xi_1^2 + xi_2^2) * ln(xi_3) + ln(xi_4)]
+    # MCDC uses the equivalent polar-form reduction
+    #   xi_1^2 / (xi_1^2 + xi_2^2) = cos(theta)^2
+    # with theta = (pi / 2) * xi3 and T(E_in) = 1 for this test table.
+    expected_E = -(math.log(xi1) + math.log(xi2) * math.cos(0.5 * PI * xi3) ** 2)
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_multi_table.py
+++ b/test/unit/transport/distributions/test_multi_table.py
@@ -1,0 +1,30 @@
+import math
+
+import mcdc.transport.distribution as dist
+
+from .test_data import make_test_multi_table_data
+
+
+def test_multi_table_distribution_sample(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.4 (Law 4: Tabular Distribution)
+    multi_table, data = make_test_multi_table_data()
+    # For E_in = 2.0 on the grid [1, 3], Eq. (2.62) gives r = 0.5.
+    # xi_2 = 0.3 < r, so Eq. (2.64) selects l = i + 1, i.e. the second table.
+    rng_sequence([0.3, 0.2])
+
+    sampled_E = dist.sample_multi_table(2.0, rng_state, multi_table, data, scale=True)
+
+    # In the selected table, xi_1 = 0.2 falls in the first continuous bin.
+    # Eq. (2.65) gives E' = E_l,k + (xi_1 - c_l,k) / p_l,k = 100 + 0.2 / 0.01 = 120.
+    # The test data use constant p within the bin, so the linear-linear form in
+    # Eq. (2.66) reduces to the same result.
+    E_prime = 100.0 + (0.2 - 0.0) / 0.01
+    # Eq. (2.67) and Eq. (2.68) give the scaled bounds:
+    #   E_1 = 10 + 0.5 * (100 - 10) = 55
+    #   E_K = 30 + 0.5 * (300 - 30) = 165
+    # Here E_l,1 = 100 and E_l,K = 300 because the selected table is the second one.
+    # Eq. (2.69) then gives
+    #   E_out = E_1 + (E' - E_l,1) * (E_K - E_1) / (E_l,K - E_l,1)
+    expected_E = 55.0 + (E_prime - 100.0) * (165.0 - 55.0) / (300.0 - 100.0)
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_nbody_correlated.py
+++ b/test/unit/transport/distributions/test_nbody_correlated.py
@@ -1,0 +1,37 @@
+import math
+
+import mcdc.transport.distribution as dist
+from mcdc.constant import DISTRIBUTION_N_BODY
+
+from .test_data import make_test_tabulated_data
+
+
+def test_nbody_sample_correlated(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.13 (Law 66: N-body Phase Space Distribution)
+    table, data = make_test_tabulated_data([2.0, 4.0, 6.0], [0.0, 0.4, 1.0])
+    mcdc = {"nbody_distributions": [table]}
+    distribution = {"child_type": DISTRIBUTION_N_BODY, "child_ID": 0}
+
+    # First value samples energy, second value samples isotropic cosine.
+    rng_sequence([0.2, 0.75])
+
+    sampled_E, sampled_mu = dist.sample_correlated_distribution(
+        2.0,
+        distribution,
+        rng_state,
+        mcdc,
+        data,
+    )
+
+    # The current implementation samples energy from the tabulated distribution and
+    # samples the cosine isotropically. This test is therefore checking the current
+    # reduced implementation, not reconstructing the full Law 66 rejection sampler
+    # from Eq. (2.103) through Eq. (2.106).
+    # For the tabulated-energy part, xi = 0.2 gives linear interpolation in the first
+    # bin. For the angular part, MCNP Eq. (2.107) gives mu = 2 * xi_10 - 1 for
+    # isotropic center-of-mass sampling.
+    expected_E = 2.0 + (0.2 - 0.0) * (4.0 - 2.0) / (0.4 - 0.0)
+    expected_mu = 2.0 * 0.75 - 1.0
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    assert math.isclose(sampled_mu, expected_mu, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_tabulated_distribution.py
+++ b/test/unit/transport/distributions/test_tabulated_distribution.py
@@ -1,0 +1,19 @@
+import math
+
+import mcdc.transport.distribution as dist
+
+from .test_data import make_test_tabulated_data
+
+
+def test_tabulated_distribution_sample(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.4 (Law 4: Tabular Distribution)
+    table, data = make_test_tabulated_data([1.0, 3.0, 7.0], [0.0, 0.4, 1.0])
+    rng_sequence([0.2])
+
+    sampled_E = dist.sample_tabulated(table, rng_state, data)
+    # This is the single-table inverse-CDF interpolation used by the tabulated sampler:
+    # xi = 0.2 lies in the first bin, so linear interpolation between
+    # (c_0, E_0) = (0.0, 1.0) and (c_1, E_1) = (0.4, 3.0) gives the expected value.
+    expected_E = 1.0 + (0.2 - 0.0) * (3.0 - 1.0) / (0.4 - 0.0)
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)

--- a/test/unit/transport/distributions/test_tabulated_energy_angle.py
+++ b/test/unit/transport/distributions/test_tabulated_energy_angle.py
@@ -1,0 +1,38 @@
+import math
+
+import mcdc.transport.distribution as dist
+
+from .test_data import make_test_tabulated_energy_angle_data
+
+
+def test_tabulated_energy_angle_sample(rng_sequence, rng_state):
+    # MCNP Theory & User Manual §2.4.3.5.4.12 (Law 61: Correlated Energy-angle Scattering)
+    table, data = make_test_tabulated_energy_angle_data()
+
+    xi1, xi2, xi3 = 0.3, 0.1, 0.25
+    rng_sequence([xi1, xi2, xi3])
+
+    sampled_E, sampled_mu = dist.sample_tabulated_energy_angle(
+        2.0, rng_state, table, data
+    )
+
+    # Law 61 uses the Law 4 energy construction first.
+    # For E_in = 2.0 on the grid [1, 3], Eq. (2.62) gives r = 0.5.
+    # xi_1 = 0.3 < r, so the second outgoing-energy table is selected.
+    # The test data again use a constant bin PDF, so the sampled E' is the
+    # Eq. (2.65) form rather than the more general Eq. (2.66) expression.
+    E_min, E_max = 1.5, 4.5
+    E_hat = 2.0 + (xi2 - 0.0) / 0.2
+    # E_min and E_max are the scaled lower and upper bounds from the two incident
+    # energy tables, i.e. the Law 4 quantities from Eq. (2.67) through Eq. (2.69).
+    expected_E = E_min + (E_hat - 2.0) / (6.0 - 2.0) * (E_max - E_min)
+
+    # For the angular table, Law 61 says the linear-interpolation case chooses the
+    # tabular angular distribution whose CDF point is closest to the sampled xi_2.
+    # Here xi_2 = 0.1 is tied between the first two CDF points in the selected energy
+    # bin, and the implementation keeps the lower index, so the first cosine table is
+    # used. Sampling that table gives mu = -1 + xi_3 / 0.5.
+    expected_mu = -1.0 + (xi3 - 0.0) / 0.5
+
+    assert math.isclose(sampled_E, expected_E, rel_tol=0.0, abs_tol=1e-12)
+    assert math.isclose(sampled_mu, expected_mu, rel_tol=0.0, abs_tol=1e-12)


### PR DESCRIPTION
Adds basic unit tests for the neutron inelastic scattering laws from the MCNP 6.3.1 manual (https://mcnp.lanl.gov/manual.html) in transport/distribution.py. 

Each test uses a set of test data with known distributions and deterministic rng sequences to compute expected analytic values of E and mu. The expected values are then compared with the sampled values from MCDC.

All the variable names and equations are pulled from the MCNP manual to hopefully keep it readable.

Currently includes: 

- Law 3: level scattering
- Law 4: tabulated distribution
- Law 4: multi-table distribution
- Law 7: simple Maxwell fission spectrum
- Law 9: evaporation spectrum
- Law 44: Kalbach-87 correlated energy-angle scattering
- Law 61: tabulated correlated energy-angle scattering
- Law 66ish: reduced N-body sampling (just checks the current implementation)

Verify with:

`pytest test/unit/transport/distributions`