### PR TITLE
Fix PR template not autopopulating

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
----
-name: General
-about: General pull request template
----
-
 ## Summary of changes
 <!--
     In at least one sentence, describe the PR you are submitting.


### PR DESCRIPTION
## Summary of changes
<!--
    In at least one sentence, describe the PR you are submitting.
-->
This PR fixes the pull request template not auto-populating when creating a PR. The problem (I think) was because I put the file in the wrong place originally, and included yaml front matter that is only meaningful with multiple templates.

## Types of changes
<!---
    What types of changes does your code introduce? Put an `x` in all the boxes that apply:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Organization and beautification (changes which improve readability and/or accessibility)

## Developer Checklist
<!---
    Please review the following checklist, and ensure you have addressed each item. Put an `x` in all boxes once completed.
-->

- [x] I have read the [contributing guide](https://mcdc.readthedocs.io/en/latest/contribution/index.html).
- [x] My code follows the [code style](https://mcdc.readthedocs.io/en/latest/contribution/index.html#code-styling) of this project.

## Associated Issues and PRs
<!--
    Please note any issues or pull requests associated with this pull request using GitHub keywords. 
    Note that for multiple issue linking, a keyword must be included before each issue.
-->

- closes #379
- related to #

## Associated Developers
<!--
    Please mention any developers who should be alerted of this PR.
-->

- Dev: @melekderman 