### PR TITLE
Fix Separate GPU States in CeMENT Branch

### DIFF
--- a/mcdc/adapt.py
+++ b/mcdc/adapt.py
@@ -513,7 +513,13 @@ def create_tally_array(width, length):
         else:
             data_tally_ptr = alloc_device_bytes(tally_size)
         data_tally_uint = voidptr_to_uintp(data_tally_ptr)
-        data_tally = numba.carray(data_tally_ptr, (width, length), type_.float64)
+        if config.gpu_state_storage == "separate":
+            data_tally = np.empty((width,length),type_.float64)
+        else:
+            data_tally = numba.carray(data_tally_ptr, (width, length), type_.float64)
+        for i in range(data_tally.shape[0]):
+            for j in range(data_tally.shape[1]):
+                data_tally[i,j] = 0
         return data_tally, data_tally_uint
     else:
         data_tally = np.zeros((width, length), dtype=type_.float64)
@@ -528,7 +534,10 @@ def create_mcdc_array():
         else:
             mcdc_ptr = alloc_device_bytes(type_.global_size)
         mcdc_uint = voidptr_to_uintp(mcdc_ptr)
-        mcdc_array = numba.carray(mcdc_ptr, (1,), type_.global_)
+        if config.gpu_state_storage == "separate":
+            mcdc_array = np.empty((1,),type_.global_)
+        else:
+            mcdc_array = numba.carray(mcdc_ptr, (1,), type_.global_)
         return mcdc_array, mcdc_uint
     else:
         mcdc_array = np.zeros((1,), dtype=type_.global_)

--- a/mcdc/adapt.py
+++ b/mcdc/adapt.py
@@ -514,12 +514,12 @@ def create_tally_array(width, length):
             data_tally_ptr = alloc_device_bytes(tally_size)
         data_tally_uint = voidptr_to_uintp(data_tally_ptr)
         if config.gpu_state_storage == "separate":
-            data_tally = np.empty((width,length),type_.float64)
+            data_tally = np.empty((width, length), type_.float64)
         else:
             data_tally = numba.carray(data_tally_ptr, (width, length), type_.float64)
         for i in range(data_tally.shape[0]):
             for j in range(data_tally.shape[1]):
-                data_tally[i,j] = 0
+                data_tally[i, j] = 0
         return data_tally, data_tally_uint
     else:
         data_tally = np.zeros((width, length), dtype=type_.float64)
@@ -535,7 +535,7 @@ def create_mcdc_array():
             mcdc_ptr = alloc_device_bytes(type_.global_size)
         mcdc_uint = voidptr_to_uintp(mcdc_ptr)
         if config.gpu_state_storage == "separate":
-            mcdc_array = np.empty((1,),type_.global_)
+            mcdc_array = np.empty((1,), type_.global_)
         else:
             mcdc_array = numba.carray(mcdc_ptr, (1,), type_.global_)
         return mcdc_array, mcdc_uint

--- a/mcdc/loop.py
+++ b/mcdc/loop.py
@@ -534,8 +534,8 @@ def gpu_loop_source(seed, data, mcdc):
 
         # Store the global state to the GPU
         if config.gpu_state_storage == "separate":
-            adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["state_pointer"], mcdc)
-            adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["state_pointer"], data)
+            adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["global_pointer"], mcdc)
+            adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["tally_pointer"], data)
 
         # Execute the program, and continue to do so until it is done
         if ASYNC_EXECUTION:
@@ -560,8 +560,8 @@ def gpu_loop_source(seed, data, mcdc):
         # Recover the original program state
 
         if config.gpu_state_storage == "separate":
-            adapt.harm.memcpy_device_to_host(mcdc, mcdc["gpu_meta"]["state_pointer"])
-            adapt.harm.memcpy_device_to_host(data, mcdc["gpu_meta"]["state_pointer"])
+            adapt.harm.memcpy_device_to_host(mcdc, mcdc["gpu_meta"]["global_pointer"])
+            adapt.harm.memcpy_device_to_host(data, mcdc["gpu_meta"]["tally_pointer"])
 
         src_clear_flags(mcdc["gpu_meta"]["source_program_pointer"])
 
@@ -903,8 +903,8 @@ def gpu_loop_source_precursor(seed, data, mcdc):
 
     # Store the global state to the GPU
     if config.gpu_state_storage == "separate":
-        adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["state_pointer"], mcdc)
-        adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["state_pointer"], data)
+        adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["global_pointer"], mcdc)
+        adapt.harm.memcpy_host_to_device(mcdc["gpu_meta"]["tally_pointer"], data)
 
     # Execute the program, and continue to do so until it is done
 
@@ -930,8 +930,8 @@ def gpu_loop_source_precursor(seed, data, mcdc):
 
     # Recover the original program state
     if config.gpu_state_storage == "separate":
-        adapt.harm.memcpy_device_to_host(mcdc, mcdc["gpu_meta"]["state_pointer"])
-        adapt.harm.memcpy_device_to_host(data, mcdc["gpu_meta"]["state_pointer"])
+        adapt.harm.memcpy_device_to_host(mcdc, mcdc["gpu_meta"]["global_pointer"])
+        adapt.harm.memcpy_device_to_host(data, mcdc["gpu_meta"]["tally_pointer"])
 
     pre_clear_flags(mcdc["gpu_meta"]["source_program_pointer"])
 

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -1180,6 +1180,9 @@ def prepare():
     mcdc_arr[0] = mcdc
     mcdc = mcdc_arr[0]
 
+    mcdc["gpu_meta"]["global_pointer"] = mcdc_uint
+    mcdc["gpu_meta"]["tally_pointer"]  = data_tally_uint
+
     # =========================================================================
     # Setting
     # =========================================================================

--- a/mcdc/main.py
+++ b/mcdc/main.py
@@ -1181,7 +1181,7 @@ def prepare():
     mcdc = mcdc_arr[0]
 
     mcdc["gpu_meta"]["global_pointer"] = mcdc_uint
-    mcdc["gpu_meta"]["tally_pointer"]  = data_tally_uint
+    mcdc["gpu_meta"]["tally_pointer"] = data_tally_uint
 
     # =========================================================================
     # Setting


### PR DESCRIPTION
Under the separate state scheme, what should be the host-side arrays were actually the device-side allocated arrays.

On APU systems, this appeared to behave perfectly fine, since "device-side" allocations are still readily accessible to CPU processes.

## Summary of changes
- Alters tally and mcdc creator functions to create host-side arrays when  `--gpu_state_storage=separate`
- Zeroes the arrays immediately after creation
- Initializes the global/tally pointers of the global field `gpu_meta`

## Types of changes
- Bug Fix